### PR TITLE
fix(web): save album/person IDs via POST body to avoid 414

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -36,6 +36,8 @@ Firmware version, update status, sunrise/sunset, and current brightness are **no
 
 Partial config files work — only settings present in the file are applied; everything else stays unchanged.
 
+**Album IDs** and **Person IDs** each must be **255 characters or fewer** after trimming (same limit as the device). If an import file exceeds that for either field, the web UI shows an error and **does not** apply that field; other settings in the file are still sent.
+
 ## File Format
 
 The export is a standard JSON file with a `version` field and grouped settings:

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,3 +35,7 @@ Requires **Chrome** or **Edge** (desktop) with [WebSerial](https://developer.moz
 2. **Flash** — Click **Install Espframe for Immich**, choose the device’s serial port, confirm. Takes a few minutes.
 3. **WiFi** — Enter network name and password when prompted. If no prompt appears, the device creates hotspot **immich-frame-10inch**; connect from phone/laptop for captive-portal setup.
 4. **Immich** — Open the device IP in a browser (shown on screen), enter **Immich server URL** and **API key**. See [API Key](/api-key) for permissions. Photos start loading. Next: [Photo Sources](/photo-sources) to choose what to display.
+
+## Recent firmware notes
+
+- **Multiple Person or Album IDs:** Saving comma-separated UUID lists uses a POST body so long lists no longer hit **414 URI Too Long**. Each of the Album IDs and Person IDs fields is still limited to **255 characters**; see [Photo Sources](/photo-sources#album-and-person-id-limits).

--- a/docs/photo-sources.md
+++ b/docs/photo-sources.md
@@ -33,6 +33,12 @@ Shows photos from one or more Immich albums. **Get the UUID:** open the album in
 
 Shows photos where specific people (faces) appear. Requires face recognition in Immich. **Get the UUID:** open the person under **People** — the URL is `.../person/<uuid>`. Paste into **Person IDs** (comma-separated for multiple). Your [API key](/api-key) needs `person.read`.
 
+## Album and Person ID limits
+
+The device stores each of **Album IDs** and **Person IDs** as a single text field with a **255 character** maximum (about **six** full UUIDs plus commas). The web UI blocks longer lists and shows an error so values are not truncated silently.
+
+Saving multiple IDs uses an HTTP POST body for the value so the request stays within URI length limits (avoiding errors such as **414 URI Too Long** when using comma-separated lists).
+
 ## Memories
 
 Shows "On this day" photos from past years; falls back to random if none. Set **Source** to **Memories**. No IDs needed. API key needs **memory.read**. Set **Timezone** (Clock) correctly so "today" matches.

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -144,6 +144,25 @@
     return fetch(fullUrl, { method: "POST" }).catch(function () {});
   }
 
+  /** Matches ESPHome template text max_length for Album / Person IDs (avoids 414 from long query strings). */
+  var MAX_PHOTO_ID_FIELD_LENGTH = 255;
+  var PHOTO_ID_FIELD_TOO_LONG =
+    "List exceeds 255 characters (device limit). Remove IDs or shorten the list.";
+
+  function postTextValueSet(url, value) {
+    var body = new URLSearchParams();
+    body.set("value", value == null ? "" : String(value));
+    return fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString()
+    }).catch(function () {});
+  }
+
+  function photoIdFieldTooLong(s) {
+    return String(s != null ? s : "").trim().length > MAX_PHOTO_ID_FIELD_LENGTH;
+  }
+
   var UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   function isValidUuidList(str) {
     var s = str.trim();
@@ -584,7 +603,7 @@
     });
 
     var albumField = field("Album IDs");
-    var albumInput = input("text", S.album_ids, "Paste album IDs, comma-separated");
+    var albumInput = input("text", S.album_ids, "Paste album IDs, comma-separated", MAX_PHOTO_ID_FIELD_LENGTH);
     var albumError = el("div", "field-error");
     var albumHint = el("div");
     albumHint.className = "field-hint";
@@ -595,7 +614,7 @@
     albumField.style.display = S.photo_source === "Album" ? "" : "none";
 
     var personField = field("Person IDs");
-    var personInput = input("text", S.person_ids, "Paste person IDs, comma-separated");
+    var personInput = input("text", S.person_ids, "Paste person IDs, comma-separated", MAX_PHOTO_ID_FIELD_LENGTH);
     var personError = el("div", "field-error");
     var personHint = el("div");
     personHint.className = "field-hint";
@@ -619,11 +638,21 @@
         personError.textContent = "Invalid UUID format";
         return;
       }
+      var albumTrim = albumInput.value.trim();
+      var personTrim = personInput.value.trim();
+      if (photoIdFieldTooLong(albumTrim)) {
+        albumError.textContent = PHOTO_ID_FIELD_TOO_LONG;
+        return;
+      }
+      if (photoIdFieldTooLong(personTrim)) {
+        personError.textContent = PHOTO_ID_FIELD_TOO_LONG;
+        return;
+      }
       applyBtn.disabled = true;
       applyBtn.textContent = "Applying\u2026";
       post(endpoints.photo_source + "/set", { option: src_val });
-      post(endpoints.album_ids + "/set", { value: albumInput.value.trim() });
-      post(endpoints.person_ids + "/set", { value: personInput.value.trim() });
+      postTextValueSet(endpoints.album_ids + "/set", albumTrim);
+      postTextValueSet(endpoints.person_ids + "/set", personTrim);
       post(eid("button", "Apply Photo Source") + "/press").then(function () {
         applyBtn.textContent = "Applied";
         setTimeout(function () {
@@ -1198,11 +1227,12 @@
     return f;
   }
 
-  function input(type, value, placeholder) {
+  function input(type, value, placeholder, maxLength) {
     var i = document.createElement("input");
     i.type = type;
     i.value = value || "";
     if (placeholder) i.placeholder = placeholder;
+    if (maxLength != null && maxLength > 0) i.maxLength = maxLength;
     return i;
   }
 
@@ -1322,12 +1352,22 @@
           post(endpoints.photo_source + "/set", { option: p.source });
         }
         if (p.album_ids !== undefined) {
-          S.album_ids = p.album_ids;
-          post(endpoints.album_ids + "/set", { value: p.album_ids });
+          var importAlbum = String(p.album_ids).trim();
+          if (photoIdFieldTooLong(importAlbum)) {
+            showBanner("Album IDs exceed 255 characters \u2014 not imported", "error");
+          } else {
+            S.album_ids = importAlbum;
+            postTextValueSet(endpoints.album_ids + "/set", importAlbum);
+          }
         }
         if (p.person_ids !== undefined) {
-          S.person_ids = p.person_ids;
-          post(endpoints.person_ids + "/set", { value: p.person_ids });
+          var importPerson = String(p.person_ids).trim();
+          if (photoIdFieldTooLong(importPerson)) {
+            showBanner("Person IDs exceed 255 characters \u2014 not imported", "error");
+          } else {
+            S.person_ids = importPerson;
+            postTextValueSet(endpoints.person_ids + "/set", importPerson);
+          }
         }
 
         if (f.interval !== undefined) {


### PR DESCRIPTION
Issue #12: long comma-separated UUID lists in query strings caused URI Too Long. Send form-urlencoded value in POST body while keeping /text/.../set paths.

- Add postTextValueSet, MAX_PHOTO_ID_FIELD_LENGTH (255), UI validation
- maxlength on ID inputs; import skips overlong fields with banner error
- Document limits and behavior in photo-sources, backup, install

Made-with: Cursor
