### PR TITLE
feat(immich): any-of person search for multiple Person IDs

### DIFF
--- a/components/espframe/README.md
+++ b/components/espframe/README.md
@@ -167,6 +167,14 @@ std::string date_str = format_photo_date(meta.year, meta.month);
 
 ### immich_helpers.h
 
+#### `split_uuid_csv(const std::string &csv)`
+
+Parses a comma-separated UUID list (optional spaces) into a vector of trimmed tokens; empty segments are skipped.
+
+#### `pick_one_person_id_for_random_search(const std::string &csv)`
+
+Returns one UUID from the list. Immich’s API applies **AND** when multiple `personIds` are sent; espframe picks a **random** person per `POST /api/search/random` so the slideshow covers **any** of the listed people over time.
+
 #### `build_uuid_json_array(const std::string &csv)`
 
 Turns a comma-separated list of UUIDs (with optional spaces) into a JSON array string, e.g. `"id1, id2"` → `["id1","id2"]`.
@@ -180,7 +188,7 @@ std::string album_ids_json = build_uuid_json_array(id(album_ids_text).state);
 #### `build_immich_search_body(size, with_people, photo_source, album_ids, person_ids, extra)`
 
 Builds the JSON body for Immich `POST /api/search/random`.  
-**Parameters:** `size` (requested count), `with_people` (include people in response), `photo_source` (e.g. `"Favorites"`, `"Album"`, `"Person"`), `album_ids` / `person_ids` (CSV UUIDs for Album/Person), optional `extra` JSON fragment (e.g. `"\"takenAfter\":\"2024-01-01\""`).
+**Parameters:** `size` (requested count), `with_people` (include people in response), `photo_source` (e.g. `"Favorites"`, `"Album"`, `"Person"`), `album_ids` / `person_ids` (CSV UUIDs for Album/Person), optional `extra` JSON fragment (e.g. `"\"takenAfter\":\"2024-01-01\""`). For **`Person`**, multiple IDs in `person_ids` are resolved to **one random ID per request** (any-of behavior vs Immich’s multi-ID AND).
 
 **Use when:** Building the body for random or “on this day” search requests.
 

--- a/components/espframe/immich_helpers.h
+++ b/components/espframe/immich_helpers.h
@@ -1,8 +1,10 @@
 #pragma once
 #include "date_utils.h"
-#include <string>
+#include "esp_random.h"
 #include <cstdint>
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 static constexpr uint16_t ZOOM_IDENTITY = 256;
 
@@ -21,22 +23,43 @@ struct ImmichAssetMeta {
 // for favorites, albums, and people. The `extra` parameter allows injecting
 // additional JSON fields (e.g. takenAfter/takenBefore for companion search).
 
-inline std::string build_uuid_json_array(const std::string &csv) {
-  std::string result = "[";
+inline std::vector<std::string> split_uuid_csv(const std::string &csv) {
+  std::vector<std::string> out;
   size_t start = 0;
-  bool first = true;
   while (start < csv.size()) {
     size_t end = csv.find(',', start);
-    if (end == std::string::npos) end = csv.size();
+    if (end == std::string::npos)
+      end = csv.size();
     size_t s = start, e = end;
-    while (s < e && csv[s] == ' ') s++;
-    while (e > s && csv[e - 1] == ' ') e--;
-    if (s < e) {
-      if (!first) result += ",";
-      result += "\"" + csv.substr(s, e - s) + "\"";
-      first = false;
-    }
+    while (s < e && csv[s] == ' ')
+      s++;
+    while (e > s && csv[e - 1] == ' ')
+      e--;
+    if (s < e)
+      out.emplace_back(csv.substr(s, e - s));
     start = end + 1;
+  }
+  return out;
+}
+
+// Immich treats multiple personIds as AND (asset must include every person).
+// For Person source we send one UUID per request so results are any-of over time.
+inline std::string pick_one_person_id_for_random_search(const std::string &csv) {
+  std::vector<std::string> ids = split_uuid_csv(csv);
+  if (ids.empty())
+    return "";
+  if (ids.size() == 1)
+    return ids[0];
+  return ids[esp_random() % ids.size()];
+}
+
+inline std::string build_uuid_json_array(const std::string &csv) {
+  std::vector<std::string> ids = split_uuid_csv(csv);
+  std::string result = "[";
+  for (size_t i = 0; i < ids.size(); i++) {
+    if (i)
+      result += ",";
+    result += "\"" + ids[i] + "\"";
   }
   result += "]";
   return result;
@@ -56,7 +79,9 @@ inline std::string build_immich_search_body(int size, bool with_people,
   } else if (photo_source == "Album" && !album_ids.empty()) {
     body += ",\"albumIds\":" + build_uuid_json_array(album_ids);
   } else if (photo_source == "Person" && !person_ids.empty()) {
-    body += ",\"personIds\":" + build_uuid_json_array(person_ids);
+    std::string one = pick_one_person_id_for_random_search(person_ids);
+    if (!one.empty())
+      body += ",\"personIds\":" + build_uuid_json_array(one);
   }
   body += "}";
   return body;

--- a/docs/photo-sources.md
+++ b/docs/photo-sources.md
@@ -31,7 +31,7 @@ Shows photos from one or more Immich albums. **Get the UUID:** open the album in
 
 ## Person
 
-Shows photos where specific people (faces) appear. Requires face recognition in Immich. **Get the UUID:** open the person under **People** — the URL is `.../person/<uuid>`. Paste into **Person IDs** (comma-separated for multiple). Your [API key](/api-key) needs `person.read`.
+Shows photos where specific people (faces) appear. Requires face recognition in Immich. **Get the UUID:** open the person under **People** — the URL is `.../person/<uuid>`. Paste into **Person IDs** (comma-separated for multiple). With several IDs, each new image is chosen from **one** of those people at random, so you see photos featuring **any** of them (not only photos where everyone appears together). Your [API key](/api-key) needs `person.read`.
 
 ## Memories
 


### PR DESCRIPTION
Immich's `POST /api/search/random` treats several `personIds` as an `AND:` where an asset must include every listed person. 

When Photo Source is Person and more than one UUID is configured, we now pick one ID at random for each search request (esp_random). Over time the slideshow draws from the union of those people's photos instead of only shots where everyone appears together.

Parsing is centralized in `split_uuid_csv()`, shared with `build_uuid_json_array()`. 

User-facing docs in photo-sources.md and
components/espframe/README.md describe the behavior.

Made-with: Cursor

Depends on #17 to enable ability to set >1 person UUID at a time.

----
Note: This is a change in default/expected behaviour of the frame

Before: Multiple people ID's would cause frame to show only photos with **all those people**
After: Multiple people ID's now shows photos with **at least one of those people**

