### PR TITLE
Fix release build integrity and pin ESPHome Docker image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,9 +53,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p docs/.vitepress/dist/firmware
-          gh release download --pattern 'manifest.json' --dir docs/.vitepress/dist/firmware/ || true
-          gh release download --pattern '*.factory.bin' --dir docs/.vitepress/dist/firmware/ || true
-          gh release download --pattern '*.ota.bin' --dir docs/.vitepress/dist/firmware/ || true
+          gh release download --pattern 'manifest.json' --dir docs/.vitepress/dist/firmware/ || echo "::warning::No manifest.json found in latest release"
+          gh release download --pattern '*.factory.bin' --dir docs/.vitepress/dist/firmware/ || echo "::warning::No factory binary found in latest release"
+          gh release download --pattern '*.ota.bin' --dir docs/.vitepress/dist/firmware/ || echo "::warning::No OTA binary found in latest release"
 
       - name: Download firmware from latest pre-release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event.release.tag_name || github.ref_name }}
 
       - name: Compile P4 firmware
         env:
@@ -26,7 +26,7 @@ jobs:
         run: >-
           docker run --rm
           -v "${PWD}:/config"
-          ghcr.io/esphome/esphome:latest
+          ghcr.io/esphome/esphome:2025.4.0
           -s firmware_version "${VERSION}"
           compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.+\\.ya?ml$"],
+      "matchStrings": ["ghcr\\.io/esphome/esphome:(?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "ghcr.io/esphome/esphome",
+      "datasourceTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Checks out the release tag instead of `default_branch` so firmware artifacts always match the tagged commit
- Pins ESPHome Docker image to `2025.4.0` for reproducible builds
- Adds Renovate custom manager to track ESPHome Docker image version updates
- Replaces silent `|| true` on firmware download with `::warning` annotations so missing release assets are visible in docs deploy logs

## Test plan
- [ ] Trigger a release and verify the checkout ref matches the tag
- [ ] Verify Renovate detects the pinned Docker image and proposes updates
- [ ] Trigger docs deploy without a release and verify warnings appear in the logs

Made with [Cursor](https://cursor.com)