### PR TITLE
Remove dead code, unused font, and fix doc drift

### DIFF
--- a/components/espframe/README.md
+++ b/components/espframe/README.md
@@ -25,8 +25,6 @@ Defined in the headers:
 | `MAX_ERROR_RETRIES` | `espframe_helpers.h` | `3` — suggested max retries for Immich API or download failures. |
 | `ACCENT_GRID_SIZE` | `espframe_helpers.h` | `20` — grid size used for sampling accent colour from images. |
 | `ZOOM_IDENTITY` | `immich_helpers.h` | `256` — no zoom (1:1). |
-| `PANORAMA_MIN_ASPECT` | `immich_helpers.h` | `1.6f` — minimum aspect ratio treated as panorama. |
-| `PANORAMA_MAX_ASPECT` | `immich_helpers.h` | `2.0f` — maximum aspect ratio for panorama zoom calculation. |
 | `MONTH_NAMES` | `date_utils.h` | `""`, `"Jan"` … `"Dec"` — short month names (index 0 unused). |
 | `TZ_DATA` | `sun_calc.h` | Array of `TzInfo` (tz id, lat, lon, POSIX TZ string) for many IANA timezones. |
 | `TZ_DATA_COUNT` | `sun_calc.h` | Number of entries in `TZ_DATA`. |

--- a/components/remote_image/bmp_image.h
+++ b/components/remote_image/bmp_image.h
@@ -9,7 +9,7 @@ namespace esphome {
 namespace remote_image {
 
 /**
- * @brief Image decoder specialization for PNG images.
+ * @brief Image decoder specialization for BMP images.
  */
 class BmpDecoder : public ImageDecoder {
  public:

--- a/components/remote_image/remote_image.cpp
+++ b/components/remote_image/remote_image.cpp
@@ -25,10 +25,6 @@ static const char *const CONTENT_TYPE_HEADER_NAME = "content-type";
 #include "webp_image.h"
 #endif
 
-#ifdef USE_ESP_IDF
-#include "soc/soc_caps.h"
-#endif
-
 namespace esphome {
 namespace remote_image {
 

--- a/guition-esp32-p4-jc8012p4a1/assets/fonts.yaml
+++ b/guition-esp32-p4-jc8012p4a1/assets/fonts.yaml
@@ -1,8 +1,8 @@
 # =============================================================================
 # FONTS - Roboto variants for clock, UI, and slideshow
 # =============================================================================
-# Google Fonts (Roboto / Roboto Light) at multiple sizes. Large sizes (150, 88)
-# use minimal glyph sets for clock digits; smaller sizes (46, 32, 30) include
+# Google Fonts (Roboto / Roboto Light) at multiple sizes. The 150px clock font
+# uses a minimal glyph set for digits; smaller sizes (46, 32, 30) include
 # full Latin + extended glyphs for setup screens and any on-screen text.
 # =============================================================================
 
@@ -13,12 +13,6 @@ font:
   - file: "gfonts://Roboto@Light"
     id: roboto_light150_font
     size: 150
-    bpp: 4
-    glyphs: " 0123456789:"
-
-  - file: "gfonts://Roboto@Light"
-    id: roboto_light88_font
-    size: 88
     bpp: 4
     glyphs: " 0123456789:"
 


### PR DESCRIPTION
## Summary
- Remove unused `roboto_light88_font` (88px font defined but never referenced -- saves flash)
- Fix BMP decoder class comment that incorrectly said "PNG images"
- Remove dead `#include "soc/soc_caps.h"` from `remote_image.cpp`
- Remove stale `PANORAMA_MIN_ASPECT` / `PANORAMA_MAX_ASPECT` references from espframe README

## Test plan
- [x] Compile verified locally -- builds successfully

Made with [Cursor](https://cursor.com)