### PR TITLE
Add HTTP error classifiers and improve error visibility

### DIFF
--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -276,22 +276,34 @@ script:
             then:
               - lambda: |-
                   if (response->status_code != 200) {
-                    ESP_LOGW("immich", "HTTP %d from Immich", response->status_code);
-                    id(immich_last_http_status) = response->status_code;
+                    int code = response->status_code;
+                    ESP_LOGW("immich", "HTTP %d from Immich", code);
+                    id(immich_last_http_status) = code;
                     int s = id(target_slot);
                     if (s == 0) id(slot0_fetch_in_flight) = false;
                     else if (s == 1) id(slot1_fetch_in_flight) = false;
                     else id(slot2_fetch_in_flight) = false;
-                    if (response->status_code == 401) {
+                    if (is_http_auth_error(code)) {
                       lv_label_set_text(id(connection_failed_title), "Invalid API Key");
                       lv_label_set_text(id(connection_failed_subtitle), "Check your Immich API key in\nthe espframe settings.");
-                      if (id(last_photo_displayed_ms) == 0) {
-                        id(last_photo_displayed_ms) = millis();
+                    } else if (is_http_retryable(code)) {
+                      id(immich_api_retries)++;
+                      if (id(immich_api_retries) < MAX_ERROR_RETRIES) {
+                        id(immich_fetch_retry).execute();
+                        return;
                       }
-                      lv_obj_clear_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN);
-                      id(connection_failed_dim).execute();
-                      id(connection_failed_shift).execute();
+                      lv_label_set_text(id(connection_failed_title), "Immich server error");
+                      lv_label_set_text(id(connection_failed_subtitle), "Your Immich server returned an error.\nIt may be restarting or under heavy load.");
+                    } else {
+                      lv_label_set_text(id(connection_failed_title), "Unable to connect to Immich");
+                      lv_label_set_text(id(connection_failed_subtitle), "Check your internet connection and\nthe health of your Immich server.");
                     }
+                    if (id(last_photo_displayed_ms) == 0) {
+                      id(last_photo_displayed_ms) = millis();
+                    }
+                    lv_obj_clear_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN);
+                    id(connection_failed_dim).execute();
+                    id(connection_failed_shift).execute();
                     return;
                   }
                   id(immich_fetch_started) = true;

--- a/components/espframe/espframe_helpers.h
+++ b/components/espframe/espframe_helpers.h
@@ -27,6 +27,12 @@ inline std::string format_time_12h(int h, int m) {
   return buf;
 }
 
+inline bool is_http_auth_error(int status) { return status == 401; }
+inline bool is_http_retryable(int status) { return status >= 500 || status == 429; }
+inline bool is_http_client_error(int status) {
+  return status >= 400 && status < 500 && !is_http_auth_error(status) && status != 429;
+}
+
 struct PhotoMeta {
   std::string asset_id, image_url, date, location, person;
   int year = 0, month = 0;


### PR DESCRIPTION
## Summary
- Add `is_http_auth_error()`, `is_http_retryable()`, `is_http_client_error()` helpers to `espframe_helpers.h`
- Use classifiers in the main fetch `on_response` to show distinct error overlays: 401 -> "Invalid API Key", 5xx/429 -> "Immich server error" (with retry), other -> "Unable to connect"
- All non-200 errors now show the connection failed overlay immediately instead of waiting silently for the photo timeout
- 5xx errors now use the existing retry mechanism before giving up

**Base:** `refactor/centralize-daytime-and-intervals` (PR #29) -- depends on the factory YAML local components change

## Test plan
- [x] Compile verified locally
- [ ] Verify 401 errors show "Invalid API Key" overlay
- [ ] Verify 5xx errors retry before showing "server error" overlay
- [ ] Verify 403/404 show generic connection error overlay immediately

Made with [Cursor](https://cursor.com)