### PR TITLE
Add compile-check workflow for PRs

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -1,0 +1,26 @@
+name: Compile Check
+
+on:
+  pull_request:
+    paths:
+      - 'common/**'
+      - 'components/**'
+      - 'guition-*/**'
+      - 'builds/**'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  compile:
+    name: Compile Firmware
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compile P4 firmware
+        run: >-
+          docker run --rm
+          -v "${PWD}:/config"
+          ghcr.io/esphome/esphome:2025.4.0
+          compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml


### PR DESCRIPTION
## Summary
- Add `compile-check.yml` workflow that triggers on PRs touching `common/`, `components/`, `guition-*/`, or `builds/`
- Runs the same ESPHome Docker compile as the release workflow (without uploading artifacts)
- Catches YAML syntax errors, C++ compilation failures, and link errors before merge

## Test plan
- [ ] Open a PR touching a firmware file and verify the workflow triggers
- [ ] Verify a compile failure correctly blocks the PR

Made with [Cursor](https://cursor.com)