### PR TITLE
Add get_slot() helper and replace ternary slot dispatches

### DIFF
--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -31,7 +31,7 @@ script:
           id(portrait_companion_url) = "";
           id(portrait_right_requested) = false;
           int ts = id(companion_target_slot);
-          auto &meta = (ts == 0) ? id(slot0) : (ts == 1) ? id(slot1) : id(slot2);
+          auto &meta = get_slot(ts, id(slot0), id(slot1), id(slot2));
           meta.companion_url = "";
           if (id(companion_target_slot) == id(active_slot)) {
             id(portrait_no_companion_active) = true;
@@ -176,7 +176,7 @@ script:
                     return;
                   }
                   int slot = id(target_slot);
-                  auto &meta = (slot == 0) ? id(slot0) : (slot == 1) ? id(slot1) : id(slot2);
+                  auto &meta = get_slot(slot, id(slot0), id(slot1), id(slot2));
                   ESP_LOGI("immich", "MEMORY slot %d: %s | %s | %s | %s | portrait=%d",
                            slot, meta.asset_id.c_str(), meta.date.c_str(), meta.person.c_str(), meta.location.c_str(), meta.is_portrait);
                   if (id(portrait_preload_slot) == slot) {
@@ -319,7 +319,7 @@ script:
                     return;
                   }
                   int slot = id(target_slot);
-                  auto &meta = (slot == 0) ? id(slot0) : (slot == 1) ? id(slot1) : id(slot2);
+                  auto &meta = get_slot(slot, id(slot0), id(slot1), id(slot2));
                   ESP_LOGI("immich", "RANDOM slot %d: %s | %s | %s | %s | portrait=%d",
                            slot, meta.asset_id.c_str(), meta.date.c_str(), meta.person.c_str(), meta.location.c_str(), meta.is_portrait);
                   if (id(portrait_preload_slot) == slot) {
@@ -470,7 +470,7 @@ script:
                   id(portrait_companion_found) = true;
                   id(portrait_companion_url) = companion_url;
                   int ts = id(companion_target_slot);
-                  auto &meta = (ts == 0) ? id(slot0) : (ts == 1) ? id(slot1) : id(slot2);
+                  auto &meta = get_slot(ts, id(slot0), id(slot1), id(slot2));
                   meta.companion_url = companion_url;
               - if:
                   condition:
@@ -488,7 +488,7 @@ script:
                   then:
                     - lambda: |-
                         int ts = id(companion_target_slot);
-                        auto &meta = (ts == 0) ? id(slot0) : (ts == 1) ? id(slot1) : id(slot2);
+                        auto &meta = get_slot(ts, id(slot0), id(slot1), id(slot2));
                         id(portrait_preload_slot) = ts;
                         id(portrait_preload_left_ready) = false;
                         id(portrait_preload_right_ready) = false;
@@ -498,7 +498,7 @@ script:
                         id: immich_portrait_preload_left
                         url: !lambda |-
                           int ts = id(companion_target_slot);
-                          auto &meta = (ts == 0) ? id(slot0) : (ts == 1) ? id(slot1) : id(slot2);
+                          auto &meta = get_slot(ts, id(slot0), id(slot1), id(slot2));
                           return meta.image_url;
                         update: false
                     - script.execute: deferred_preload_left_update

--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -428,14 +428,14 @@ remote_image:
               lambda: |-
                 int ps = id(portrait_preload_slot);
                 if (ps < 0) return false;
-                auto &meta = (ps == 0) ? id(slot0) : (ps == 1) ? id(slot1) : id(slot2);
+                auto &meta = get_slot(ps, id(slot0), id(slot1), id(slot2));
                 return !meta.companion_url.empty();
             then:
               - remote_image.set_url:
                   id: immich_portrait_preload_right
                   url: !lambda |-
                     int ps = id(portrait_preload_slot);
-                    auto &meta = (ps == 0) ? id(slot0) : (ps == 1) ? id(slot1) : id(slot2);
+                    auto &meta = get_slot(ps, id(slot0), id(slot1), id(slot2));
                     return meta.companion_url;
                   update: false
               - script.execute: deferred_preload_right_update
@@ -496,7 +496,7 @@ script:
           id(immich_download_retries)++;
           int s = id(last_downloaded_slot);
           ESP_LOGE("immich", "Slot %d decode failed (attempt %d)", s, id(immich_download_retries));
-          auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+          auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
           meta.ready = false;
           meta.asset_id = "";
           meta.pending_asset_id = "";
@@ -522,7 +522,7 @@ script:
             - script.stop: immich_start_portrait_active
       - lambda: |-
           int s = id(active_slot);
-          auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+          auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
           id(portrait_left_ready) = false;
           id(portrait_right_ready) = false;
           id(portrait_no_companion_active) = false;
@@ -545,7 +545,7 @@ script:
           id: immich_portrait_left
           url: !lambda |-
             int s = id(active_slot);
-            auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+            auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
             return meta.image_url;
           update: false
       - script.execute: deferred_portrait_left_update
@@ -585,7 +585,7 @@ script:
           esphome::image::Image *imgs[] = { id(immich_img_0), id(immich_img_1), id(immich_img_2) };
           lv_img_set_src(id(slideshow_img), imgs[s]->get_lv_img_dsc());
 
-          auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+          auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
           lv_img_set_zoom(id(slideshow_img), meta.zoom);
           ESP_LOGI("immich", "SHOW slot %d: %s | %s | %s | portrait=%d", s, meta.asset_id.c_str(), meta.date.c_str(), meta.person.c_str(), meta.is_portrait);
           bool pair = meta.is_portrait && id(portrait_pairing_enabled).state;
@@ -599,7 +599,7 @@ script:
           condition:
             lambda: |-
               int s = id(active_slot);
-              auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+              auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
               return meta.is_portrait && id(portrait_pairing_enabled).state && id(portrait_preload_slot) == s
                      && id(portrait_preload_left_ready) && id(portrait_preload_right_ready);
           then:
@@ -625,7 +625,7 @@ script:
           condition:
             lambda: |-
               int s = id(active_slot);
-              auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+              auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
               return meta.is_portrait && id(portrait_pairing_enabled).state && !id(immich_is_portrait_pair) && !id(portrait_no_companion_active);
           then:
             - script.execute: immich_start_portrait_active
@@ -641,7 +641,7 @@ script:
           then:
             - lambda: |-
                 int s = id(active_slot);
-                auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+                auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
                 if (meta.ready && id(active_portrait_workflow_busy)) {
                   // #region agent log
                   ESP_LOGW("diag", "H1-FIX: Recovering stuck portrait workflow — displaying slot %d as single", s);
@@ -685,7 +685,7 @@ script:
             - lambda: |-
                 if (!id(current_display).asset_id.empty()) {
                   int s_old = id(active_slot);
-                  auto &old_meta = (s_old == 0) ? id(slot0) : (s_old == 1) ? id(slot1) : id(slot2);
+                  auto &old_meta = get_slot(s_old, id(slot0), id(slot1), id(slot2));
                   id(prev_display) = id(current_display);
                   id(prev_display).zoom = old_meta.zoom;
                   id(prev_display).valid = true;
@@ -701,7 +701,7 @@ script:
                 int old_slot_idx = id(active_slot);
                 id(active_slot) = (old_slot_idx + 1) % 3;
                 id(active_slot_displayed) = false;
-                auto &cleared = (old_slot_idx == 0) ? id(slot0) : (old_slot_idx == 1) ? id(slot1) : id(slot2);
+                auto &cleared = get_slot(old_slot_idx, id(slot0), id(slot1), id(slot2));
                 cleared.ready = false;
                 id(immich_last_advance_ms) = millis();
                 ESP_LOGI("immich", "ADVANCE: slot %d -> %d", old_slot_idx, id(active_slot));
@@ -709,12 +709,12 @@ script:
                 condition:
                   lambda: |-
                     int s = id(active_slot);
-                    auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+                    auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
                     return meta.ready;
                 then:
                   - lambda: |-
                       int s = id(active_slot);
-                      auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+                      auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
                       copy_slot_to_display(meta, id(current_display));
                       bool pair = meta.is_portrait && id(portrait_pairing_enabled).state;
                       if (!pair) id(active_slot_displayed) = true;
@@ -724,7 +724,7 @@ script:
                       condition:
                         lambda: |-
                           int s = id(active_slot);
-                          auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+                          auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
                           return !(meta.is_portrait && id(portrait_pairing_enabled).state);
                       then:
                         - script.execute: immich_display_current
@@ -733,7 +733,7 @@ script:
                       condition:
                         lambda: |-
                           int s = id(active_slot);
-                          auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+                          auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
                           return meta.is_portrait && id(portrait_pairing_enabled).state && id(portrait_preload_slot) == s
                                  && id(portrait_preload_left_ready) && id(portrait_preload_right_ready);
                       then:
@@ -743,7 +743,7 @@ script:
                       condition:
                         lambda: |-
                           int s = id(active_slot);
-                          auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
+                          auto &meta = get_slot(s, id(slot0), id(slot1), id(slot2));
                           return meta.is_portrait && id(portrait_pairing_enabled).state && !(id(portrait_preload_slot) == s
                                  && id(portrait_preload_left_ready) && id(portrait_preload_right_ready));
                       then:
@@ -780,7 +780,7 @@ script:
           else:
             - lambda: |-
                 int cur_s = id(active_slot);
-                auto &cur_meta = (cur_s == 0) ? id(slot0) : (cur_s == 1) ? id(slot1) : id(slot2);
+                auto &cur_meta = get_slot(cur_s, id(slot0), id(slot1), id(slot2));
                 DisplayMeta tmp = id(current_display);
                 tmp.zoom = cur_meta.zoom;
 
@@ -800,7 +800,7 @@ script:
                 id(active_slot) = prev_slot;
                 id(active_slot_displayed) = false;
 
-                auto &meta = (prev_slot == 0) ? id(slot0) : (prev_slot == 1) ? id(slot1) : id(slot2);
+                auto &meta = get_slot(prev_slot, id(slot0), id(slot1), id(slot2));
                 meta.ready = false;
                 meta.is_portrait = false;
                 meta.companion_url = "";
@@ -864,7 +864,7 @@ script:
           // are still in progress (active pair or preload pair).
           bool active_portrait_busy = false;
           if (id(active_slot) == 0 || id(active_slot) == 1 || id(active_slot) == 2) {
-            auto &active = (id(active_slot) == 0) ? id(slot0) : (id(active_slot) == 1) ? id(slot1) : id(slot2);
+            auto &active = get_slot(id(active_slot), id(slot0), id(slot1), id(slot2));
             if (active.is_portrait) {
               bool left_pending = !id(portrait_left_ready);
               bool right_pending = id(portrait_companion_found) && !id(portrait_right_ready);
@@ -893,8 +893,8 @@ script:
           }
           int next1 = (id(active_slot) + 1) % 3;
           int next2 = (id(active_slot) + 2) % 3;
-          auto &n1 = (next1 == 0) ? id(slot0) : (next1 == 1) ? id(slot1) : id(slot2);
-          auto &n2 = (next2 == 0) ? id(slot0) : (next2 == 1) ? id(slot1) : id(slot2);
+          auto &n1 = get_slot(next1, id(slot0), id(slot1), id(slot2));
+          auto &n2 = get_slot(next2, id(slot0), id(slot1), id(slot2));
           bool n1_in_flight = (next1 == 0) ? id(slot0_fetch_in_flight) : (next1 == 1) ? id(slot1_fetch_in_flight) : id(slot2_fetch_in_flight);
           bool n2_in_flight = (next2 == 0) ? id(slot0_fetch_in_flight) : (next2 == 1) ? id(slot1_fetch_in_flight) : id(slot2_fetch_in_flight);
           if (!n1.ready && !n1_in_flight) {

--- a/components/espframe/espframe_helpers.h
+++ b/components/espframe/espframe_helpers.h
@@ -48,6 +48,10 @@ struct DisplayMeta : PhotoMeta {
   bool valid = false;
 };
 
+inline SlotMeta& get_slot(int s, SlotMeta &s0, SlotMeta &s1, SlotMeta &s2) {
+  return (s == 0) ? s0 : (s == 1) ? s1 : s2;
+}
+
 inline void copy_slot_to_display(const SlotMeta &slot, DisplayMeta &disp) {
   static_cast<PhotoMeta&>(disp) = static_cast<const PhotoMeta&>(slot);
 }

--- a/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -329,8 +329,8 @@ interval:
               if (any_inflight || id(active_portrait_workflow_busy) || id(noncritical_remote_updates_in_flight) > 0) return false;
               int next1 = (id(active_slot) + 1) % 3;
               int next2 = (id(active_slot) + 2) % 3;
-              auto &n1 = (next1 == 0) ? id(slot0) : (next1 == 1) ? id(slot1) : id(slot2);
-              auto &n2 = (next2 == 0) ? id(slot0) : (next2 == 1) ? id(slot1) : id(slot2);
+              auto &n1 = get_slot(next1, id(slot0), id(slot1), id(slot2));
+              auto &n2 = get_slot(next2, id(slot0), id(slot1), id(slot2));
               return !n1.ready || !n2.ready;
           then:
             - script.execute: immich_prefetch_chain


### PR DESCRIPTION
## Summary
- Add `get_slot(index, s0, s1, s2)` to `espframe_helpers.h` for indexed slot access
- Replace 29 instances of `(x == 0) ? id(slot0) : (x == 1) ? id(slot1) : id(slot2)` ternary chains with `get_slot(x, id(slot0), id(slot1), id(slot2))` across all YAML files
- Improves readability and makes the slot-dispatch pattern consistent and searchable

This is the first step toward full slot deduplication. The per-slot `fetch_in_flight` and `noncritical_update` boolean globals (~95 remaining dispatch sites) are candidates for a follow-up that folds them into the `SlotMeta` struct.

**Base:** `refactor/http-error-classifiers` (PR #30)

## Test plan
- [x] Compile verified locally
- [ ] Verify slideshow navigation, prefetch, and portrait pairing work correctly

Made with [Cursor](https://cursor.com)