### PR TITLE
Extract decode_url_commas helper and deduplicate filter flush logic

### DIFF
--- a/common/addon/immich_filter.yaml
+++ b/common/addon/immich_filter.yaml
@@ -43,11 +43,7 @@ text:
     icon: "mdi:folder-image"
     set_action:
       - lambda: |-
-          std::string v = x;
-          for (size_t p = v.find("%2C"); p != std::string::npos; p = v.find("%2C", p + 1))
-            v.replace(p, 3, ",");
-          for (size_t p = v.find("%2c"); p != std::string::npos; p = v.find("%2c", p + 1))
-            v.replace(p, 3, ",");
+          std::string v = decode_url_commas(x);
           id(immich_album_ids).publish_state(v);
           ESP_LOGI("immich", "Album IDs configured (%d chars)", v.length());
       - script.execute: auto_apply_photo_source
@@ -64,11 +60,7 @@ text:
     icon: "mdi:account-group"
     set_action:
       - lambda: |-
-          std::string v = x;
-          for (size_t p = v.find("%2C"); p != std::string::npos; p = v.find("%2C", p + 1))
-            v.replace(p, 3, ",");
-          for (size_t p = v.find("%2c"); p != std::string::npos; p = v.find("%2c", p + 1))
-            v.replace(p, 3, ",");
+          std::string v = decode_url_commas(x);
           id(immich_person_ids).publish_state(v);
           ESP_LOGI("immich", "Person IDs configured (%d chars)", v.length());
       - script.execute: auto_apply_photo_source
@@ -84,30 +76,16 @@ button:
     icon: "mdi:check-circle"
     on_press:
       - script.stop: auto_apply_photo_source
-      - lambda: |-
-          id(slot0).ready = false;
-          id(slot1).ready = false;
-          id(slot2).ready = false;
-          id(portrait_preload_slot) = -1;
-          id(portrait_preload_left_ready) = false;
-          id(portrait_preload_right_ready) = false;
-          if (id(preload_noncritical_in_flight)) {
-            id(preload_noncritical_in_flight) = false;
-            if (id(noncritical_remote_updates_in_flight) > 0) id(noncritical_remote_updates_in_flight)--;
-          }
-          id(active_slot_displayed) = false;
-          id(target_slot) = id(active_slot);
-          ESP_LOGI("immich", "Photo source applied — flushing all slots");
-      - script.execute: immich_fetch_into_slot
+      - lambda: 'ESP_LOGI("immich", "Photo source applied — flushing all slots");'
+      - script.execute: flush_slots_and_refetch
 
 # -----------------------------------------------------------------------------
 # Delayed auto-apply after source/album/person change
 # -----------------------------------------------------------------------------
 script:
-  - id: auto_apply_photo_source
-    mode: restart
+  - id: flush_slots_and_refetch
+    mode: single
     then:
-      - delay: 1s
       - lambda: |-
           id(slot0).ready = false;
           id(slot1).ready = false;
@@ -121,5 +99,11 @@ script:
           }
           id(active_slot_displayed) = false;
           id(target_slot) = id(active_slot);
-          ESP_LOGI("immich", "Photo source auto-applied — flushing all slots");
       - script.execute: immich_fetch_into_slot
+
+  - id: auto_apply_photo_source
+    mode: restart
+    then:
+      - delay: 1s
+      - lambda: 'ESP_LOGI("immich", "Photo source auto-applied — flushing all slots");'
+      - script.execute: flush_slots_and_refetch

--- a/components/espframe/espframe_helpers.h
+++ b/components/espframe/espframe_helpers.h
@@ -48,6 +48,15 @@ struct DisplayMeta : PhotoMeta {
   bool valid = false;
 };
 
+inline std::string decode_url_commas(const std::string &input) {
+  std::string v = input;
+  for (size_t p = v.find("%2C"); p != std::string::npos; p = v.find("%2C", p + 1))
+    v.replace(p, 3, ",");
+  for (size_t p = v.find("%2c"); p != std::string::npos; p = v.find("%2c", p + 1))
+    v.replace(p, 3, ",");
+  return v;
+}
+
 inline SlotMeta& get_slot(int s, SlotMeta &s0, SlotMeta &s1, SlotMeta &s2) {
   return (s == 0) ? s0 : (s == 1) ? s1 : s2;
 }


### PR DESCRIPTION
## Summary
- Add `decode_url_commas()` to `espframe_helpers.h` -- replaces duplicated `%2C`/`%2c` URL-decode loops in album and person ID `set_action` handlers
- Extract shared `flush_slots_and_refetch` script from the identical slot flush blocks in `apply_photo_source` (button) and `auto_apply_photo_source` (script)

**Base:** `refactor/slot-helpers` (PR #32)

## Test plan
- [x] Compile verified locally
- [ ] Verify album/person ID input with URL-encoded commas works correctly
- [ ] Verify "Apply Photo Source" button and auto-apply both flush and refetch properly

Made with [Cursor](https://cursor.com)