### PR TITLE
Cleanup: remove dead code, diagnostics, and unused declarations

### DIFF
--- a/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
@@ -5,7 +5,7 @@
 # for WiFi setup via captive portal.
 #
 # Compiled by CI (see .github/workflows/release.yml) — not used locally.
-# For local development, use dev.yaml in the device folder instead.
+# For local development, see guition-esp32-p4-jc8012p4a1/esphome.yaml.
 # =============================================================================
 
 substitutions:

--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -235,9 +235,6 @@ script:
           condition:
             lambda: 'return id(target_slot) != id(active_slot) && id(active_portrait_workflow_busy);'
           then:
-            # #region agent log
-            - lambda: 'ESP_LOGW("diag", "H1: fetch slot %d BLOCKED (busy flag)", id(target_slot));'
-            # #endregion
             - script.execute: delayed_prefetch_chain
             - script.stop: immich_fetch_into_slot
       - if:
@@ -379,9 +376,6 @@ script:
           condition:
             lambda: 'return id(companion_target_slot) != id(active_slot) && id(active_portrait_workflow_busy);'
           then:
-            # #region agent log
-            - lambda: 'ESP_LOGW("diag", "H1: companion search BLOCKED (busy flag)");'
-            # #endregion
             - script.execute: delayed_prefetch_chain
             - script.stop: immich_fetch_portrait_companion
       - lambda: |-

--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -364,9 +364,6 @@ remote_image:
             ESP_LOGE("immich", "Portrait left decode failed, falling back to single");
             id(portrait_left_ready) = false;
             id(portrait_companion_found) = false;
-            // #region agent log
-            ESP_LOGW("diag", "H5: portrait LEFT error, displayed=%d busy=%d", id(active_slot_displayed), id(active_portrait_workflow_busy));
-            // #endregion
             if (!id(active_slot_displayed)) {
               id(active_slot_displayed) = true;
               id(active_portrait_workflow_busy) = false;
@@ -398,9 +395,6 @@ remote_image:
             id(portrait_right_ready) = false;
             id(portrait_right_requested) = false;
             id(portrait_companion_found) = false;
-            // #region agent log
-            ESP_LOGW("diag", "H1: portrait RIGHT error, displayed=%d busy=%d", id(active_slot_displayed), id(active_portrait_workflow_busy));
-            // #endregion
             if (!id(active_slot_displayed)) {
               id(active_slot_displayed) = true;
               id(active_portrait_workflow_busy) = false;
@@ -643,9 +637,6 @@ script:
                 int s = id(active_slot);
                 auto &meta = (s == 0) ? id(slot0) : (s == 1) ? id(slot1) : id(slot2);
                 if (meta.ready && id(active_portrait_workflow_busy)) {
-                  // #region agent log
-                  ESP_LOGW("diag", "H1-FIX: Recovering stuck portrait workflow — displaying slot %d as single", s);
-                  // #endregion
                   id(active_portrait_workflow_busy) = false;
                   id(portrait_left_ready) = false;
                   id(portrait_right_ready) = false;
@@ -877,16 +868,8 @@ script:
             ESP_LOGD("immich", "Prefetch deferred (portrait pipeline busy)");
             return;
           }
-          // #region agent log
-          if (id(active_portrait_workflow_busy)) {
-            ESP_LOGW("diag", "H1: prefetch BLOCKED by active_portrait_workflow_busy");
-            return;
-          }
-          if (id(noncritical_remote_updates_in_flight) > 0) {
-            ESP_LOGW("diag", "H2: prefetch BLOCKED by nc_flight=%d", id(noncritical_remote_updates_in_flight));
-            return;
-          }
-          // #endregion
+          if (id(active_portrait_workflow_busy)) return;
+          if (id(noncritical_remote_updates_in_flight) > 0) return;
           if ((millis() - id(last_prefetch_start_ms)) < 600) {
             ESP_LOGD("immich", "Prefetch throttled");
             return;
@@ -943,18 +926,10 @@ script:
       - lambda: |-
           int s = 0;
           bool noncritical = (s != id(active_slot));
-          // #region agent log
-          if (noncritical && id(active_portrait_workflow_busy)) {
-            ESP_LOGW("diag", "H1: slot %d update DEFERRED (busy flag)", s);
+          if (noncritical && (id(active_portrait_workflow_busy) || id(noncritical_remote_updates_in_flight) > 0)) {
             id(delayed_prefetch_chain).execute();
             return;
           }
-          if (noncritical && id(noncritical_remote_updates_in_flight) > 0) {
-            ESP_LOGW("diag", "H2: slot %d update DEFERRED (nc_flight=%d)", s, id(noncritical_remote_updates_in_flight));
-            id(delayed_prefetch_chain).execute();
-            return;
-          }
-          // #endregion
           if (noncritical && !id(slot0_noncritical_update)) {
             id(slot0_noncritical_update) = true;
             id(noncritical_remote_updates_in_flight)++;
@@ -972,18 +947,10 @@ script:
       - lambda: |-
           int s = 1;
           bool noncritical = (s != id(active_slot));
-          // #region agent log
-          if (noncritical && id(active_portrait_workflow_busy)) {
-            ESP_LOGW("diag", "H1: slot %d update DEFERRED (busy flag)", s);
+          if (noncritical && (id(active_portrait_workflow_busy) || id(noncritical_remote_updates_in_flight) > 0)) {
             id(delayed_prefetch_chain).execute();
             return;
           }
-          if (noncritical && id(noncritical_remote_updates_in_flight) > 0) {
-            ESP_LOGW("diag", "H2: slot %d update DEFERRED (nc_flight=%d)", s, id(noncritical_remote_updates_in_flight));
-            id(delayed_prefetch_chain).execute();
-            return;
-          }
-          // #endregion
           if (noncritical && !id(slot1_noncritical_update)) {
             id(slot1_noncritical_update) = true;
             id(noncritical_remote_updates_in_flight)++;
@@ -1001,18 +968,10 @@ script:
       - lambda: |-
           int s = 2;
           bool noncritical = (s != id(active_slot));
-          // #region agent log
-          if (noncritical && id(active_portrait_workflow_busy)) {
-            ESP_LOGW("diag", "H1: slot %d update DEFERRED (busy flag)", s);
+          if (noncritical && (id(active_portrait_workflow_busy) || id(noncritical_remote_updates_in_flight) > 0)) {
             id(delayed_prefetch_chain).execute();
             return;
           }
-          if (noncritical && id(noncritical_remote_updates_in_flight) > 0) {
-            ESP_LOGW("diag", "H2: slot %d update DEFERRED (nc_flight=%d)", s, id(noncritical_remote_updates_in_flight));
-            id(delayed_prefetch_chain).execute();
-            return;
-          }
-          // #endregion
           if (noncritical && !id(slot2_noncritical_update)) {
             id(slot2_noncritical_update) = true;
             id(noncritical_remote_updates_in_flight)++;
@@ -1046,13 +1005,10 @@ script:
     then:
       - delay: 150ms
       - lambda: |-
-          // #region agent log
           if (id(active_portrait_workflow_busy)) {
-            ESP_LOGW("diag", "H1: preload-left DEFERRED (busy flag)");
             id(delayed_prefetch_chain).execute();
             return;
           }
-          // #endregion
           if (!id(preload_noncritical_in_flight)) {
             id(preload_noncritical_in_flight) = true;
             id(noncritical_remote_updates_in_flight)++;
@@ -1064,9 +1020,7 @@ script:
     then:
       - delay: 150ms
       - lambda: |-
-          // #region agent log
           if (id(active_portrait_workflow_busy)) {
-            ESP_LOGW("diag", "H1: preload-right DEFERRED (busy flag), cleaning nc state");
             if (id(preload_noncritical_in_flight)) {
               id(preload_noncritical_in_flight) = false;
               if (id(noncritical_remote_updates_in_flight) > 0) id(noncritical_remote_updates_in_flight)--;
@@ -1074,5 +1028,4 @@ script:
             id(delayed_prefetch_chain).execute();
             return;
           }
-          // #endregion
           id(immich_portrait_preload_right).update();

--- a/guition-esp32-p4-jc8012p4a1/assets/fonts.yaml
+++ b/guition-esp32-p4-jc8012p4a1/assets/fonts.yaml
@@ -16,12 +16,6 @@ font:
     bpp: 4
     glyphs: " 0123456789:"
 
-  - file: "gfonts://Roboto@Light"
-    id: roboto_light88_font
-    size: 88
-    bpp: 4
-    glyphs: " 0123456789:"
-
 # -----------------------------------------------------------------------------
 # UI and setup text (full Latin + extended glyphs)
 # -----------------------------------------------------------------------------

--- a/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -32,14 +32,6 @@ esphome:
     board_build.flash_mode: dio
     build_flags:
       - "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y"
-  # #region agent log
-  on_boot:
-    - priority: 900
-      then:
-        - lambda: |-
-            esphome::watchdog::WatchdogManager *wdm = new esphome::watchdog::WatchdogManager(30000);
-            ESP_LOGW("diag", "H6: Watchdog timeout set to 30s (leaked WatchdogManager to keep it permanent)");
-  # #endregion
 
 # -----------------------------------------------------------------------------
 # ESP32-C6 coprocessor (WiFi and Bluetooth via SDIO)
@@ -84,11 +76,6 @@ text_sensor:
   - platform: debug
     reset_reason:
       name: "Reset Reason"
-      # #region agent log
-      on_value:
-        then:
-          - lambda: 'ESP_LOGW("diag", "H6: RESET REASON: %s", x.c_str());'
-      # #endregion
 
 json:
 

--- a/guition-esp32-p4-jc8012p4a1/packages.yaml
+++ b/guition-esp32-p4-jc8012p4a1/packages.yaml
@@ -7,7 +7,6 @@
 # =============================================================================
 
 substitutions:
-  device_slug: "guition-esp32-p4-jc8012p4a1"
   display_width: "1280"
   display_height: "800"
   portrait_half_width: "640"


### PR DESCRIPTION
## Summary
- Remove unused `roboto_light88_font` font definition (saves flash and build time)
- Remove unused `device_slug` substitution from packages.yaml
- Strip all `#region agent log` diagnostic blocks (~70 lines of noise across 3 files)
- Remove leaked `WatchdogManager` allocation from `on_boot` and debug `reset_reason` handler
- Fix factory.yaml comment that referenced a nonexistent `dev.yaml`

## Test plan
- [ ] Compile firmware successfully
- [ ] Verify no behavioral changes — device boots and operates identically

Made with [Cursor](https://cursor.com)