### PR TITLE
Fix remote_image reliability bugs and harden error handling

### DIFF
--- a/components/espframe/sun_calc.h
+++ b/components/espframe/sun_calc.h
@@ -259,14 +259,18 @@ inline float parse_tz_offset(const std::string &tz_label) {
   size_t idx = 0;
   if (offset_str[idx] == '+') { sign = 1.0f; idx++; }
   else if (offset_str[idx] == '-') { sign = -1.0f; idx++; }
-  // Strip trailing ')'
   auto paren = offset_str.find(')');
   if (paren != std::string::npos) offset_str = offset_str.substr(0, paren);
+  char *end = nullptr;
   auto colon = offset_str.find(':', idx);
   if (colon != std::string::npos) {
-    float hours = std::stof(offset_str.substr(idx, colon - idx));
-    float mins = std::stof(offset_str.substr(colon + 1));
+    float hours = strtof(offset_str.c_str() + idx, &end);
+    if (end == offset_str.c_str() + idx) return 0.0f;
+    float mins = strtof(offset_str.c_str() + colon + 1, &end);
+    if (end == offset_str.c_str() + colon + 1) return 0.0f;
     return sign * (hours + mins / 60.0f);
   }
-  return sign * std::stof(offset_str.substr(idx));
+  float val = strtof(offset_str.c_str() + idx, &end);
+  if (end == offset_str.c_str() + idx) return 0.0f;
+  return sign * val;
 }

--- a/components/remote_image/bmp_image.cpp
+++ b/components/remote_image/bmp_image.cpp
@@ -89,9 +89,12 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
     case 1: {
       while (index < size) {
         uint8_t current_byte = buffer[index];
-        for (uint8_t i = 0; i < 8; i++) {
-          size_t x = (this->paint_index_ % this->width_) + i;
-          size_t y = (this->height_ - 1) - (this->paint_index_ / this->width_);
+        uint8_t bits_remaining = std::min(static_cast<uint8_t>(8),
+                                          static_cast<uint8_t>(this->width_ - (this->paint_index_ % this->width_)));
+        for (uint8_t i = 0; i < bits_remaining; i++) {
+          size_t pix = this->paint_index_ + i;
+          size_t x = pix % this->width_;
+          size_t y = (this->height_ - 1) - (pix / this->width_);
           Color c = (current_byte & (1 << (7 - i))) ? display::COLOR_ON : display::COLOR_OFF;
           this->draw(x, y, 1, 1, c);
         }

--- a/components/remote_image/image_decoder.cpp
+++ b/components/remote_image/image_decoder.cpp
@@ -9,6 +9,10 @@ namespace remote_image {
 static const char *const TAG = "remote_image.decoder";
 
 bool ImageDecoder::set_size(int width, int height) {
+  if (width <= 0 || height <= 0) {
+    ESP_LOGE(TAG, "Invalid image dimensions: %dx%d", width, height);
+    return false;
+  }
   bool success = this->image_->resize_(width, height) > 0;
 
   int buf_w = this->image_->buffer_width_;
@@ -163,6 +167,10 @@ uint8_t *DownloadBuffer::data(size_t offset) {
 }
 
 size_t DownloadBuffer::read(size_t len) {
+  if (len > this->unread_) {
+    ESP_LOGE(TAG, "DownloadBuffer::read(%zu) exceeds unread %zu, clamping", len, this->unread_);
+    len = this->unread_;
+  }
   this->unread_ -= len;
   if (this->unread_ > 0) {
     memmove(this->data(), this->data(len), this->unread_);
@@ -194,9 +202,14 @@ size_t DownloadBuffer::resize(size_t size) {
 
 void DownloadBuffer::shrink(size_t max_size) {
   if (this->size_ <= max_size) return;
+  auto *new_buffer = this->allocator_.allocate(max_size);
+  if (!new_buffer) {
+    ESP_LOGW(TAG, "shrink allocation failed, keeping existing %zu-byte buffer", this->size_);
+    return;
+  }
   this->allocator_.deallocate(this->buffer_, this->size_);
-  this->buffer_ = this->allocator_.allocate(max_size);
-  this->size_ = this->buffer_ ? max_size : 0;
+  this->buffer_ = new_buffer;
+  this->size_ = max_size;
   this->reset();
 }
 

--- a/components/remote_image/png_image.h
+++ b/components/remote_image/png_image.h
@@ -30,7 +30,7 @@ class PngDecoder : public ImageDecoder {
 
  protected:
   RAMAllocator<pngle_t> allocator_;
-  pngle_t *pngle_;
+  pngle_t *pngle_{nullptr};
   uint32_t pixels_decoded_{0};
 };
 

--- a/components/remote_image/remote_image.cpp
+++ b/components/remote_image/remote_image.cpp
@@ -278,7 +278,12 @@ void OnlineImage::loop() {
     }
     return;
   }
-  if (!this->downloader_ || this->decoder_->is_finished()) {
+  if (!this->downloader_) {
+    ESP_LOGW(TAG, "Downloader disappeared mid-transfer");
+    this->download_error_callback_.call();
+    return;
+  }
+  if (this->decoder_->is_finished()) {
     this->data_start_ = buffer_;
     this->width_ = buffer_width_;
     this->height_ = buffer_height_;


### PR DESCRIPTION
## Summary
- Guard null `downloader_` dereference in `OnlineImage::loop()` success path
- Initialize `pngle_` to `nullptr` to prevent indeterminate pointer on alloc failure
- Clamp `DownloadBuffer::read()` to prevent `size_t` underflow/corruption
- Allocate-before-free in `DownloadBuffer::shrink()` to survive allocation failure
- Validate positive dimensions in `ImageDecoder::set_size()` before building LUT
- Fix BMP 1bpp bit-to-pixel mapping — each bit now gets its own pixel index, with padding bit clamping at row boundaries
- Replace `std::stof` with `strtof` in `parse_tz_offset` to avoid potential exceptions on malformed timezone labels

## Test plan
- [ ] Compile firmware successfully
- [ ] Test JPEG, PNG, and WebP image loading from Immich
- [ ] Verify no visual or behavioral changes to slideshow

Made with [Cursor](https://cursor.com)