### PR TITLE
Replace hardcoded LVGL dimensions and captive portal IP with substitutions

### DIFF
--- a/guition-esp32-p4-jc8012p4a1/device/screen_immich_setup.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/screen_immich_setup.yaml
@@ -12,8 +12,8 @@ lvgl:
       scrollable: false
       widgets:
         - obj:
-            width: 1280
-            height: 800
+            width: ${display_width}
+            height: ${display_height}
             bg_opa: 0%
             border_width: 0
             pad_all: 0

--- a/guition-esp32-p4-jc8012p4a1/device/screen_loading.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/screen_loading.yaml
@@ -88,7 +88,7 @@ esphome:
             lv_label_set_text(id(loading_status_label), "Connecting to WiFi");
         - lambda: |-
             std::string name = App.get_name();
-            std::string wifi_text = "Connect to the WiFi hotspot\n'" + name + "'\nto configure your network\n\nThen visit 192.168.4.1 in your browser";
+            std::string wifi_text = "Connect to the WiFi hotspot\n'" + name + "'\nto configure your network\n\nThen visit ${captive_portal_ip} in your browser";
             lv_label_set_text(id(wifi_setup_instructions), wifi_text.c_str());
         - delay: 10s
         - lambda: 'id(boot_grace_period) = false;'

--- a/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -55,8 +55,8 @@ lvgl:
         - obj:
             id: portrait_pair_container
             align: CENTER
-            width: 1280
-            height: 800
+            width: ${display_width}
+            height: ${display_height}
             bg_color: 0x000000
             bg_opa: 100%
             border_width: 0
@@ -95,8 +95,8 @@ lvgl:
                 - script.stop: backlight_hold_timer
             widgets:
               - obj:
-                  width: 640
-                  height: 800
+                  width: ${portrait_half_width}
+                  height: ${display_height}
                   bg_opa: 0%
                   border_width: 0
                   pad_all: 0
@@ -110,8 +110,8 @@ lvgl:
                         scrollable: false
                         clickable: false
               - obj:
-                  width: 640
-                  height: 800
+                  width: ${portrait_half_width}
+                  height: ${display_height}
                   bg_opa: 0%
                   border_width: 0
                   pad_all: 0
@@ -170,8 +170,8 @@ lvgl:
         - obj:
             id: connection_failed_overlay
             align: CENTER
-            width: 1280
-            height: 800
+            width: ${display_width}
+            height: ${display_height}
             radius: 0
             bg_color: 0x000000
             bg_opa: 100%

--- a/guition-esp32-p4-jc8012p4a1/device/screen_wifi_setup.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/screen_wifi_setup.yaml
@@ -12,8 +12,8 @@ lvgl:
       pad_all: 0
       widgets:
         - obj:
-            width: 1280
-            height: 800
+            width: ${display_width}
+            height: ${display_height}
             bg_opa: 0%
             border_width: 0
             pad_all: 0
@@ -54,7 +54,7 @@ lvgl:
                         text_align: center
                     - label:
                         id: wifi_setup_instructions
-                        text: "Connect to the WiFi hotspot\nto configure your network\n\nThen visit 192.168.4.1 in your browser"
+                        text: "Connect to the WiFi hotspot\nto configure your network\n\nThen visit ${captive_portal_ip} in your browser"
                         text_font: roboto30_font
                         text_color: 0x888888
                         width: 700

--- a/guition-esp32-p4-jc8012p4a1/packages.yaml
+++ b/guition-esp32-p4-jc8012p4a1/packages.yaml
@@ -11,6 +11,7 @@ substitutions:
   display_width: "1280"
   display_height: "800"
   portrait_half_width: "640"
+  captive_portal_ip: "192.168.4.1"
   firmware_manifest_url: "https://jtenniswood.github.io/espframe/firmware/manifest.json"
   firmware_beta_manifest_url: "https://jtenniswood.github.io/espframe/firmware/beta/manifest.json"
 


### PR DESCRIPTION
## Summary
- Replace literal `1280`, `800`, `640` with `${display_width}`, `${display_height}`, `${portrait_half_width}` in all screen YAML files
- Add `captive_portal_ip` substitution and use it in WiFi setup and loading screen text
- A future panel only requires changing `packages.yaml` instead of editing dozens of lines

## Test plan
- [ ] Compile firmware successfully
- [ ] Verify all screens render identically (loading, WiFi setup, Immich setup, slideshow, portrait pairs, connection failed overlay)

Made with [Cursor](https://cursor.com)