### PR TITLE
Extract large YAML lambdas into C++ helper functions

### DIFF
--- a/common/addon/accent_color.yaml
+++ b/common/addon/accent_color.yaml
@@ -20,124 +20,17 @@ script:
     mode: restart
     then:
       - lambda: |-
-          auto fill_accent = [](esphome::image::Image *img) {
-            int img_w = img->get_width();
-            int img_h = img->get_height();
-            if (img_w <= 0 || img_h <= 0) return;
-
-            lv_img_dsc_t *dsc = img->get_lv_img_dsc();
-            const uint8_t *data = dsc->data;
-            if (!data) return;
-
-            int x_off = 0;
-            int mid_y = img_h / 2;
-            for (int x = 0; x < img_w / 2; x++) {
-              int pos = (x + mid_y * img_w) * 2;
-              uint16_t px = data[pos] | (data[pos + 1] << 8);
-              if (px != 0x0000) { x_off = x; break; }
-            }
-            int y_off = 0;
-            int mid_x = img_w / 2;
-            for (int y = 0; y < img_h / 2; y++) {
-              int pos = (mid_x + y * img_w) * 2;
-              uint16_t px = data[pos] | (data[pos + 1] << 8);
-              if (px != 0x0000) { y_off = y; break; }
-            }
-
-            if (x_off == 0 && y_off == 0) return;
-
-            int content_w = img_w - 2 * x_off;
-            int content_h = img_h - 2 * y_off;
-            int grid = ACCENT_GRID_SIZE;
-            int step_x = content_w / grid;
-            int step_y = content_h / grid;
-            if (step_x < 1) step_x = 1;
-            if (step_y < 1) step_y = 1;
-
-            int64_t r_wsum = 0, g_wsum = 0, b_wsum = 0;
-            int64_t w_total = 0;
-
-            for (int sy = y_off + step_y / 2; sy < img_h - y_off; sy += step_y) {
-              for (int sx = x_off + step_x / 2; sx < img_w - x_off; sx += step_x) {
-                int pos = (sx + sy * img_w) * 2;
-                uint16_t rgb565 = data[pos] | (data[pos + 1] << 8);
-
-                int r = ((rgb565 >> 11) & 0x1F);
-                int g = ((rgb565 >> 5) & 0x3F);
-                int b = (rgb565 & 0x1F);
-                r = (r << 3) | (r >> 2);
-                g = (g << 2) | (g >> 4);
-                b = (b << 3) | (b >> 2);
-
-                int mx = r > g ? (r > b ? r : b) : (g > b ? g : b);
-                int mn = r < g ? (r < b ? r : b) : (g < b ? g : b);
-                int sat = mx - mn;
-
-                int weight = sat * sat + 1;
-                r_wsum += (int64_t)r * weight;
-                g_wsum += (int64_t)g * weight;
-                b_wsum += (int64_t)b * weight;
-                w_total += weight;
-              }
-            }
-
-            if (w_total <= 0) return;
-
-            int r = (int)(r_wsum / w_total);
-            int g = (int)(g_wsum / w_total);
-            int b = (int)(b_wsum / w_total);
-            ESP_LOGI("accent", "Accent rgb(%d,%d,%d) offset x=%d y=%d", r, g, b, x_off, y_off);
-
-            int dr = r / 2, dg = g / 2, db = b / 2;
-            uint16_t accent_565 = ((dr >> 3) << 11) | ((dg >> 2) << 5) | (db >> 3);
-            uint8_t lo = accent_565 & 0xFF;
-            uint8_t hi = (accent_565 >> 8) & 0xFF;
-
-            uint8_t *buf = const_cast<uint8_t*>(data);
-            int row_bytes = img_w * 2;
-
-            // Build one full accent row for top/bottom bar fills
-            if (y_off > 0) {
-              for (int x = 0; x < img_w; x++) {
-                buf[x * 2] = lo; buf[x * 2 + 1] = hi;
-              }
-              for (int y = 1; y < y_off; y++)
-                memcpy(buf + y * row_bytes, buf, row_bytes);
-              for (int y = img_h - y_off; y < img_h; y++)
-                memcpy(buf + y * row_bytes, buf, row_bytes);
-            }
-
-            // Build one column segment for left/right bar fills
-            if (x_off > 0) {
-              int col_bytes = x_off * 2;
-              uint8_t col_buf[${display_width}];
-              if (col_bytes > (int)sizeof(col_buf)) return;
-              for (int x = 0; x < x_off; x++) {
-                col_buf[x * 2] = lo; col_buf[x * 2 + 1] = hi;
-              }
-              for (int y = y_off; y < img_h - y_off; y++) {
-                int row = y * row_bytes;
-                memcpy(buf + row, col_buf, col_bytes);
-                memcpy(buf + row + (img_w - x_off) * 2, col_buf, col_bytes);
-              }
-            }
-          };
-
           if (id(immich_is_portrait_pair)) {
             if (id(portrait_using_preload)) {
-              fill_accent(id(immich_portrait_preload_left));
-              fill_accent(id(immich_portrait_preload_right));
+              fill_accent_color(id(immich_portrait_preload_left));
+              fill_accent_color(id(immich_portrait_preload_right));
             } else {
-              fill_accent(id(immich_portrait_left));
-              fill_accent(id(immich_portrait_right));
+              fill_accent_color(id(immich_portrait_left));
+              fill_accent_color(id(immich_portrait_right));
             }
             lv_obj_invalidate(id(portrait_pair_container));
           } else {
-            esphome::image::Image *img = nullptr;
-            int s = id(active_slot);
-            if (s == 0) img = id(immich_img_0);
-            else if (s == 1) img = id(immich_img_1);
-            else img = id(immich_img_2);
-            fill_accent(img);
+            esphome::image::Image *imgs[] = { id(immich_img_0), id(immich_img_1), id(immich_img_2) };
+            fill_accent_color(imgs[id(active_slot)]);
             lv_obj_invalidate(id(slideshow_img));
           }

--- a/common/addon/backlight_schedule.yaml
+++ b/common/addon/backlight_schedule.yaml
@@ -267,12 +267,9 @@ script:
           id(sunrise_sunset_valid) = true;
 
           char buf[16];
-          snprintf(buf, sizeof(buf), "%d:%02d AM", (rh == 0) ? 12 : (rh > 12 ? rh - 12 : rh), rm);
-          if (rh >= 12) snprintf(buf, sizeof(buf), "%d:%02d PM", (rh == 12) ? 12 : rh - 12, rm);
+          format_time_12h(rh, rm, buf, sizeof(buf));
           id(sunrise_time_sensor).publish_state(buf);
-
-          snprintf(buf, sizeof(buf), "%d:%02d PM", (sh == 12) ? 12 : (sh > 12 ? sh - 12 : sh), sm);
-          if (sh < 12) snprintf(buf, sizeof(buf), "%d:%02d AM", (sh == 0) ? 12 : sh, sm);
+          format_time_12h(sh, sm, buf, sizeof(buf));
           id(sunset_time_sensor).publish_state(buf);
 
           // Integer-only log: avoids newlib float formatting (_dtoa_r) during heap work under load.

--- a/common/addon/warm_tones.yaml
+++ b/common/addon/warm_tones.yaml
@@ -119,112 +119,48 @@ script:
           bool retint = id(warm_tone_retint);
           id(warm_tone_retint) = false;
 
-          // Base tone: correction for display blue cast (only when enabled)
           float base_w = id(base_tone_enabled).state ? (id(base_tone).state / 100.0f) : 0.0f;
 
-          // Night warmth: sun-based or manual override
           float night_w = 0.0f;
-          bool override_on = id(warm_tone_override).state;
-          if (override_on) {
+          if (id(warm_tone_override).state) {
             night_w = id(warm_tone_intensity).state / 100.0f;
           } else if (id(warm_tones_enabled).state && id(sunrise_sunset_valid)) {
             auto now = id(sntp_time).now();
             if (!now.is_valid() && base_w < 0.01f) return;
             if (now.is_valid()) {
-              int now_min = now.hour * 60 + now.minute;
-              int rise_min = id(sunrise_hour) * 60 + id(sunrise_minute);
-              int set_min  = id(sunset_hour)  * 60 + id(sunset_minute);
-              float warmth = 0.0f;
-              if (now_min >= set_min) {
-                warmth = 1.0f;
-              } else if (now_min >= set_min - WARM_TONE_LEAD_MINUTES) {
-                warmth = (float)(now_min - (set_min - WARM_TONE_LEAD_MINUTES)) / WARM_TONE_LEAD_MINUTES;
-              } else if (now_min < rise_min) {
-                warmth = 1.0f;
-              } else if (now_min < rise_min + WARM_TONE_LEAD_MINUTES) {
-                warmth = 1.0f - (float)(now_min - rise_min) / WARM_TONE_LEAD_MINUTES;
-              }
+              float warmth = calc_sun_warmth(
+                now.hour * 60 + now.minute,
+                id(sunrise_hour) * 60 + id(sunrise_minute),
+                id(sunset_hour) * 60 + id(sunset_minute),
+                WARM_TONE_LEAD_MINUTES);
               night_w = warmth * (id(warm_tone_intensity).state / 100.0f);
             }
           }
 
           float w = base_w + night_w;
-
-          // When called from a toggle change, buffer already has a tint applied.
-          // When called from the normal pipeline (new image), buffer is fresh.
           float last_w = retint ? id(warm_tone_last_w) : 0.0f;
-
-          // Skip if the buffer already has the target warmth applied
           if (fabsf(w - last_w) < 0.01f) return;
 
-          // Integer-only log (no %f / _dtoa_r) — warmth is ~0..1
-          int last_c = (int)(last_w * 100.0f + 0.5f);
-          int w_c = (int)(w * 100.0f + 0.5f);
-          if (last_c > 100) last_c = 100;
-          if (w_c > 100) w_c = 100;
+          int last_c = std::min((int)(last_w * 100.0f + 0.5f), 100);
+          int w_c = std::min((int)(w * 100.0f + 0.5f), 100);
           ESP_LOGI("warm", "Warmth=%d.%02d->%d.%02d (intensity=%d%%)",
                    last_c / 100, last_c % 100, w_c / 100, w_c % 100, (int)id(warm_tone_intensity).state);
 
-          // Build transition LUTs: undo last_w, apply new w in a single step.
-          // For each channel value in the buffer (which has last_w baked in),
-          // recover the original value then apply the new w.
-          float r_undo = (last_w > 0.005f) ? 1.0f / (1.0f + last_w * 0.06f) : 1.0f;
-          float g_undo = (last_w > 0.005f) ? 1.0f / (1.0f - last_w * 0.07f) : 1.0f;
-          float b_undo = (last_w > 0.005f) ? 1.0f / (1.0f - last_w * 0.28f) : 1.0f;
-          float r_apply = 1.0f + w * 0.06f;
-          float g_apply = 1.0f - w * 0.07f;
-          float b_apply = 1.0f - w * 0.28f;
-
-          uint8_t r_lut[32], g_lut[64], b_lut[32];
-          for (int i = 0; i < 32; i++) {
-            int v = (i << 3) | (i >> 2);
-            int nv = (int)(v * r_undo * r_apply);
-            r_lut[i] = (uint8_t)((nv > 255 ? 255 : (nv < 0 ? 0 : nv)) >> 3);
-          }
-          for (int i = 0; i < 64; i++) {
-            int v = (i << 2) | (i >> 4);
-            int nv = (int)(v * g_undo * g_apply);
-            g_lut[i] = (uint8_t)((nv > 255 ? 255 : (nv < 0 ? 0 : nv)) >> 2);
-          }
-          for (int i = 0; i < 32; i++) {
-            int v = (i << 3) | (i >> 2);
-            int nv = (int)(v * b_undo * b_apply);
-            b_lut[i] = (uint8_t)((nv > 255 ? 255 : (nv < 0 ? 0 : nv)) >> 3);
-          }
-
-          auto tint_buffer = [&](esphome::image::Image *img) {
-            if (!img) return;
-            lv_img_dsc_t *dsc = img->get_lv_img_dsc();
-            if (!dsc || !dsc->data) return;
-            uint8_t *buf = const_cast<uint8_t*>(dsc->data);
-            int total = img->get_width() * img->get_height();
-            for (int i = 0; i < total; i++) {
-              int pos = i * 2;
-              uint16_t px = buf[pos] | (buf[pos + 1] << 8);
-              uint8_t r5 = r_lut[(px >> 11) & 0x1F];
-              uint8_t g6 = g_lut[(px >> 5) & 0x3F];
-              uint8_t b5 = b_lut[px & 0x1F];
-              uint16_t out = (r5 << 11) | (g6 << 5) | b5;
-              buf[pos]     = out & 0xFF;
-              buf[pos + 1] = (out >> 8) & 0xFF;
-            }
-          };
+          WarmToneLuts luts;
+          build_warm_tone_luts(last_w, w, luts);
 
           if (id(immich_is_portrait_pair)) {
             if (id(portrait_using_preload)) {
-              tint_buffer(id(immich_portrait_preload_left));
-              tint_buffer(id(immich_portrait_preload_right));
+              tint_image_buffer(id(immich_portrait_preload_left), luts);
+              tint_image_buffer(id(immich_portrait_preload_right), luts);
             } else {
-              tint_buffer(id(immich_portrait_left));
-              tint_buffer(id(immich_portrait_right));
+              tint_image_buffer(id(immich_portrait_left), luts);
+              tint_image_buffer(id(immich_portrait_right), luts);
             }
             lv_obj_invalidate(id(portrait_pair_container));
           } else {
-            int s = id(active_slot);
-            esphome::image::Image *img = (s == 0) ? id(immich_img_0)
-                                       : (s == 1) ? id(immich_img_1)
-                                       :            id(immich_img_2);
-            tint_buffer(img);
+            esphome::image::Image *imgs[] = { id(immich_img_0), id(immich_img_1), id(immich_img_2) };
+            tint_image_buffer(imgs[id(active_slot)], luts);
             lv_obj_invalidate(id(slideshow_img));
           }
 

--- a/components/espframe/espframe_helpers.h
+++ b/components/espframe/espframe_helpers.h
@@ -4,10 +4,17 @@
 #include "sun_calc.h"
 #include <string>
 #include <cstdint>
+#include <cstring>
+#include <cmath>
+
+#ifdef USE_LVGL
+#include "esphome/components/image/image.h"
+#endif
 
 static constexpr int MAX_ERROR_RETRIES = 3;
 static constexpr int ACCENT_GRID_SIZE = 20;
 static constexpr int WARM_TONE_LEAD_MINUTES = 60;
+static constexpr int ACCENT_COL_BUF_MAX = 2560;
 
 struct PhotoMeta {
   std::string asset_id, image_url, date, location, person;
@@ -40,6 +47,184 @@ inline void copy_display_to_slot(const DisplayMeta &disp, SlotMeta &slot) {
 // slot: target slot index (0, 1, or 2).
 // s0, s1, s2: references to the three SlotMeta globals.
 // Returns the image URL on success, empty string on parse failure.
+
+// ============================================================================
+// Accent color fill — detect letterbox bars and fill with dominant accent
+// ============================================================================
+#ifdef USE_LVGL
+inline void fill_accent_color(esphome::image::Image *img) {
+  int img_w = img->get_width();
+  int img_h = img->get_height();
+  if (img_w <= 0 || img_h <= 0) return;
+
+  lv_img_dsc_t *dsc = img->get_lv_img_dsc();
+  const uint8_t *data = dsc->data;
+  if (!data) return;
+
+  int x_off = 0;
+  int mid_y = img_h / 2;
+  for (int x = 0; x < img_w / 2; x++) {
+    int pos = (x + mid_y * img_w) * 2;
+    uint16_t px = data[pos] | (data[pos + 1] << 8);
+    if (px != 0x0000) { x_off = x; break; }
+  }
+  int y_off = 0;
+  int mid_x = img_w / 2;
+  for (int y = 0; y < img_h / 2; y++) {
+    int pos = (mid_x + y * img_w) * 2;
+    uint16_t px = data[pos] | (data[pos + 1] << 8);
+    if (px != 0x0000) { y_off = y; break; }
+  }
+
+  if (x_off == 0 && y_off == 0) return;
+
+  int content_w = img_w - 2 * x_off;
+  int content_h = img_h - 2 * y_off;
+  int grid = ACCENT_GRID_SIZE;
+  int step_x = content_w / grid;
+  int step_y = content_h / grid;
+  if (step_x < 1) step_x = 1;
+  if (step_y < 1) step_y = 1;
+
+  int64_t r_wsum = 0, g_wsum = 0, b_wsum = 0;
+  int64_t w_total = 0;
+
+  for (int sy = y_off + step_y / 2; sy < img_h - y_off; sy += step_y) {
+    for (int sx = x_off + step_x / 2; sx < img_w - x_off; sx += step_x) {
+      int pos = (sx + sy * img_w) * 2;
+      uint16_t rgb565 = data[pos] | (data[pos + 1] << 8);
+      int r = ((rgb565 >> 11) & 0x1F);
+      int g = ((rgb565 >> 5) & 0x3F);
+      int b = (rgb565 & 0x1F);
+      r = (r << 3) | (r >> 2);
+      g = (g << 2) | (g >> 4);
+      b = (b << 3) | (b >> 2);
+      int mx = r > g ? (r > b ? r : b) : (g > b ? g : b);
+      int mn = r < g ? (r < b ? r : b) : (g < b ? g : b);
+      int sat = mx - mn;
+      int weight = sat * sat + 1;
+      r_wsum += (int64_t)r * weight;
+      g_wsum += (int64_t)g * weight;
+      b_wsum += (int64_t)b * weight;
+      w_total += weight;
+    }
+  }
+
+  if (w_total <= 0) return;
+
+  int r = (int)(r_wsum / w_total);
+  int g = (int)(g_wsum / w_total);
+  int b = (int)(b_wsum / w_total);
+
+  int dr = r / 2, dg = g / 2, db = b / 2;
+  uint16_t accent_565 = ((dr >> 3) << 11) | ((dg >> 2) << 5) | (db >> 3);
+  uint8_t lo = accent_565 & 0xFF;
+  uint8_t hi = (accent_565 >> 8) & 0xFF;
+
+  uint8_t *buf = const_cast<uint8_t*>(data);
+  int row_bytes = img_w * 2;
+
+  if (y_off > 0) {
+    for (int x = 0; x < img_w; x++) {
+      buf[x * 2] = lo; buf[x * 2 + 1] = hi;
+    }
+    for (int y = 1; y < y_off; y++)
+      memcpy(buf + y * row_bytes, buf, row_bytes);
+    for (int y = img_h - y_off; y < img_h; y++)
+      memcpy(buf + y * row_bytes, buf, row_bytes);
+  }
+
+  if (x_off > 0) {
+    int col_bytes = x_off * 2;
+    uint8_t col_buf[ACCENT_COL_BUF_MAX];
+    if (col_bytes > (int)sizeof(col_buf)) return;
+    for (int x = 0; x < x_off; x++) {
+      col_buf[x * 2] = lo; col_buf[x * 2 + 1] = hi;
+    }
+    for (int y = y_off; y < img_h - y_off; y++) {
+      int row = y * row_bytes;
+      memcpy(buf + row, col_buf, col_bytes);
+      memcpy(buf + row + (img_w - x_off) * 2, col_buf, col_bytes);
+    }
+  }
+}
+#endif  // USE_LVGL
+
+// ============================================================================
+// Warm tone helpers — LUT-based RGB565 tinting
+// ============================================================================
+
+inline float calc_sun_warmth(int now_min, int rise_min, int set_min, int lead_min) {
+  if (now_min >= set_min) return 1.0f;
+  if (now_min >= set_min - lead_min)
+    return (float)(now_min - (set_min - lead_min)) / lead_min;
+  if (now_min < rise_min) return 1.0f;
+  if (now_min < rise_min + lead_min)
+    return 1.0f - (float)(now_min - rise_min) / lead_min;
+  return 0.0f;
+}
+
+struct WarmToneLuts {
+  uint8_t r[32];
+  uint8_t g[64];
+  uint8_t b[32];
+};
+
+inline void build_warm_tone_luts(float last_w, float new_w, WarmToneLuts &luts) {
+  float r_undo = (last_w > 0.005f) ? 1.0f / (1.0f + last_w * 0.06f) : 1.0f;
+  float g_undo = (last_w > 0.005f) ? 1.0f / (1.0f - last_w * 0.07f) : 1.0f;
+  float b_undo = (last_w > 0.005f) ? 1.0f / (1.0f - last_w * 0.28f) : 1.0f;
+  float r_apply = 1.0f + new_w * 0.06f;
+  float g_apply = 1.0f - new_w * 0.07f;
+  float b_apply = 1.0f - new_w * 0.28f;
+
+  for (int i = 0; i < 32; i++) {
+    int v = (i << 3) | (i >> 2);
+    int nv = (int)(v * r_undo * r_apply);
+    luts.r[i] = (uint8_t)((nv > 255 ? 255 : (nv < 0 ? 0 : nv)) >> 3);
+  }
+  for (int i = 0; i < 64; i++) {
+    int v = (i << 2) | (i >> 4);
+    int nv = (int)(v * g_undo * g_apply);
+    luts.g[i] = (uint8_t)((nv > 255 ? 255 : (nv < 0 ? 0 : nv)) >> 2);
+  }
+  for (int i = 0; i < 32; i++) {
+    int v = (i << 3) | (i >> 2);
+    int nv = (int)(v * b_undo * b_apply);
+    luts.b[i] = (uint8_t)((nv > 255 ? 255 : (nv < 0 ? 0 : nv)) >> 3);
+  }
+}
+
+#ifdef USE_LVGL
+inline void tint_image_buffer(esphome::image::Image *img, const WarmToneLuts &luts) {
+  if (!img) return;
+  lv_img_dsc_t *dsc = img->get_lv_img_dsc();
+  if (!dsc || !dsc->data) return;
+  uint8_t *buf = const_cast<uint8_t*>(dsc->data);
+  int total = img->get_width() * img->get_height();
+  for (int i = 0; i < total; i++) {
+    int pos = i * 2;
+    uint16_t px = buf[pos] | (buf[pos + 1] << 8);
+    uint8_t r5 = luts.r[(px >> 11) & 0x1F];
+    uint8_t g6 = luts.g[(px >> 5) & 0x3F];
+    uint8_t b5 = luts.b[px & 0x1F];
+    uint16_t out = (r5 << 11) | (g6 << 5) | b5;
+    buf[pos]     = out & 0xFF;
+    buf[pos + 1] = (out >> 8) & 0xFF;
+  }
+}
+#endif  // USE_LVGL
+
+// ============================================================================
+// Time formatting — 12-hour AM/PM format for sunrise/sunset display
+// ============================================================================
+
+inline void format_time_12h(int hour24, int minute, char *buf, size_t buf_size) {
+  const char *suffix = (hour24 >= 12) ? "PM" : "AM";
+  int h12 = hour24 % 12;
+  if (h12 == 0) h12 = 12;
+  snprintf(buf, buf_size, "%d:%02d %s", h12, minute, suffix);
+}
 
 #ifdef USE_JSON
 inline std::string parse_immich_asset_and_fill_slot(const std::string &body,


### PR DESCRIPTION
## Summary
Move ~300 lines of inline C++ from YAML lambdas into proper functions in `espframe_helpers.h`:

- **`fill_accent_color()`** — detect letterbox bars and fill with saturation-weighted dominant color (from `accent_color.yaml`)
- **`calc_sun_warmth()`** — compute sun-based warmth ramp from sunrise/sunset times (from `warm_tones.yaml`)
- **`build_warm_tone_luts()` + `tint_image_buffer()`** — LUT-based RGB565 warm tone tinting (from `warm_tones.yaml`)
- **`format_time_12h()`** — 12-hour AM/PM formatting for sunrise/sunset display (from `backlight_schedule.yaml`)

YAML lambdas reduced to thin glue code (~50 lines total), improving readability, compile-time type checking, and IDE support.

## Test plan
- [ ] Compile firmware successfully
- [ ] Verify accent color fill appears correctly on letterboxed images
- [ ] Verify warm tone tinting works at sunset/sunrise transitions
- [ ] Verify sunrise/sunset times display correctly in AM/PM format
- [ ] Verify "Warm until sunrise" override works and auto-disables

Made with [Cursor](https://cursor.com)