### PR TITLE
Harden GSL3680 touch driver and document vendor code

### DIFF
--- a/components/gsl3680/gsl3680.cpp
+++ b/components/gsl3680/gsl3680.cpp
@@ -15,7 +15,9 @@ void GSL3680::setup() {
     this->reset_pin_->setup();
 
     this->reset_pin_->digital_write(false);
+    esphome::delay(5);
     this->reset_pin_->digital_write(true);
+    esphome::delay(10);
 
     auto err = this->init();
     if (err != esphome::i2c::ERROR_OK) {
@@ -123,6 +125,7 @@ esphome::i2c::ErrorCode GSL3680::load_firmware() {
         wrbuf[2] = (uint8_t)((GSLX680_FW[i].val & 0x00ff0000) >> 16);
         wrbuf[3] = (uint8_t)((GSLX680_FW[i].val & 0xff000000) >> 24);
         STOP_ON_I2C_ERROR(err, this->write_register(addr, (uint8_t *)&wrbuf, addr == 0xf0? 1: 4));
+        if (i % 256 == 0) App.feed_wdt();
     }
     ESP_LOGD(TAG,"Load firmware complete");
     return err;
@@ -193,12 +196,18 @@ void GSL3680::update_touches() {
 
     if ((mask > 0) && (mask < 0xffffffff)) {
         uint8_t buf[4] = {0xa, 0x0, 0x0, 0x0};
-        this->write_register(0xf0, (uint8_t *)&buf, 4);
+        auto mask_err = this->write_register(0xf0, (uint8_t *)&buf, 4);
+        if (mask_err != esphome::i2c::ERROR_OK) {
+            ESP_LOGW(TAG, "I2C mask write 0xf0 failed: %d", mask_err);
+        }
         buf[0] = (uint8_t)(mask & 0xff);
         buf[1] = (uint8_t)((mask >> 8) & 0xff);
         buf[2] = (uint8_t)((mask >> 16) & 0xff);
         buf[3] = (uint8_t)((mask >> 24) & 0xff);
-        this->write_register(0x8, (uint8_t *)&buf, 4);
+        mask_err = this->write_register(0x8, (uint8_t *)&buf, 4);
+        if (mask_err != esphome::i2c::ERROR_OK) {
+            ESP_LOGW(TAG, "I2C mask write 0x08 failed: %d", mask_err);
+        }
     }
 
     ESP_LOGV(TAG, "update_touches: touch [%d] %dx%d (%d)", cinfo.finger_num, cinfo.x[0], cinfo.y[0], mask);

--- a/components/gsl3680/gsl_point_id.cpp
+++ b/components/gsl3680/gsl_point_id.cpp
@@ -1,3 +1,15 @@
+// ============================================================================
+// FROZEN VENDOR CODE — DO NOT EDIT
+// ============================================================================
+// Silead GSL3680 touch point identification algorithm.
+// Ported from the Silead Linux kernel driver (GPL-2.0).
+// Version: GSL_VERSION 0x20160901 (2016-09-01, no-gesture variant)
+//
+// This file contains global mutable state and is not re-entrant. It is called
+// only from GSL3680::update_touches() on a single task.
+//
+// Any modifications require hardware regression testing on the target panel.
+// ============================================================================
 /* drivers/input/touchscreen/mediatek/gslX680/
  *
  * 2010 - 2016 silead inc.


### PR DESCRIPTION
## Summary
- Add 5ms/10ms delays to reset pulse for reliable hardware initialization
- Feed watchdog every 256 firmware entries during long I2C load in `setup()` to prevent WDT timeout on strict configs
- Check I2C return codes on mask writes in `update_touches()` and log warnings on failure
- Add frozen vendor code header to `gsl_point_id.cpp` documenting GSL version (0x20160901), thread safety constraints, and modification policy

## Test plan
- [ ] Compile firmware successfully
- [ ] Verify touch works correctly on device
- [ ] Monitor logs for any new I2C warnings during mask writes

Made with [Cursor](https://cursor.com)