### PR TITLE
[codex] Port PR 17 album/person ID save fix

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -36,6 +36,8 @@ Firmware version, update status, sunrise/sunset, and current brightness are **no
 
 Partial config files work — only settings present in the file are applied; everything else stays unchanged.
 
+Album IDs and Person IDs each must be 255 characters or fewer after trimming, which matches the device storage limit. If an import file exceeds that for either field, the web UI shows an error and skips that field; other settings in the file are still sent.
+
 ## File Format
 
 The export is a standard JSON file with a `version` field and grouped settings:

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,3 +39,7 @@ Requires **Chrome** or **Edge** (desktop) with [WebSerial](https://developer.moz
 2. **Flash** — Click **Install Espframe for Immich**, choose the device’s serial port, confirm. Takes a few minutes.
 3. **WiFi** — Enter network name and password when prompted. If no prompt appears, the device creates hotspot **immich-frame-10inch**; connect from phone/laptop for captive-portal setup.
 4. **Immich** — Open the device IP in a browser (shown on screen), enter **Immich server URL** and **API key**. See [API Key](/api-key) for permissions. Photos start loading. Next: [Photo Sources](/photo-sources) to choose what to display.
+
+## Recent firmware notes
+
+- **Multiple Person or Album IDs:** Saving comma-separated UUID lists uses a POST body so long lists no longer hit **414 URI Too Long**. Album IDs and Person IDs are still limited to **255 characters** each; see [Photo Sources](/photo-sources#album-and-person-id-limits).

--- a/docs/photo-sources.md
+++ b/docs/photo-sources.md
@@ -33,6 +33,12 @@ Shows photos from one or more Immich albums. **Get the UUID:** open the album in
 
 Shows photos where specific people (faces) appear. Requires face recognition in Immich. **Get the UUID:** open the person under **People** — the URL is `.../person/<uuid>`. Paste into **Person IDs** (comma-separated for multiple). With several IDs, each new image is chosen from **one** of those people at random, so you see photos featuring **any** of them (not only photos where everyone appears together). Your [API key](/api-key) needs `person.read`.
 
+## Album and Person ID limits
+
+The device stores each of **Album IDs** and **Person IDs** as a single text field with a **255 character** maximum, which is about six full UUIDs plus commas. The web UI blocks longer lists and shows an error so values are not silently cut short.
+
+Saving multiple IDs uses an HTTP POST body for the value, so the request stays within URL length limits and avoids errors such as **414 URI Too Long**.
+
 ## Memories
 
 Shows "On this day" photos from past years; falls back to random if none. Set **Source** to **Memories**. No IDs needed. API key needs **memory.read**. Set **Timezone** (Clock) correctly so "today" matches.

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -464,6 +464,31 @@
     });
   }
 
+  // Matches the ESPHome template text max_length for album/person ID lists.
+  var MAX_PHOTO_ID_FIELD_LENGTH = 255;
+  var PHOTO_ID_FIELD_TOO_LONG =
+    "List exceeds 255 characters (device limit). Remove IDs or shorten the list.";
+
+  function postTextValueSet(url, value) {
+    var body = new URLSearchParams();
+    body.set("value", value == null ? "" : String(value));
+    return fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString()
+    }).then(function (r) {
+      if (!r.ok) console.error("POST " + url + " failed: " + r.status);
+      return r;
+    }).catch(function (err) {
+      console.error("POST " + url + " error:", err);
+      showBanner("Failed to save setting", "error");
+    });
+  }
+
+  function photoIdFieldTooLong(s) {
+    return String(s != null ? s : "").trim().length > MAX_PHOTO_ID_FIELD_LENGTH;
+  }
+
   var UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   function isValidUuidList(str) {
     var s = str.trim();
@@ -938,7 +963,7 @@
     });
 
     var albumField = field("Album IDs");
-    var albumInput = input("text", S.album_ids, "Paste album IDs, comma-separated");
+    var albumInput = input("text", S.album_ids, "Paste album IDs, comma-separated", MAX_PHOTO_ID_FIELD_LENGTH);
     var albumError = el("div", "field-error");
     var albumHint = el("div");
     albumHint.className = "field-hint";
@@ -949,7 +974,7 @@
     albumField.style.display = S.photo_source === "Album" ? "" : "none";
 
     var personField = field("Person IDs");
-    var personInput = input("text", S.person_ids, "Paste person IDs, comma-separated");
+    var personInput = input("text", S.person_ids, "Paste person IDs, comma-separated", MAX_PHOTO_ID_FIELD_LENGTH);
     var personError = el("div", "field-error");
     var personHint = el("div");
     personHint.className = "field-hint";
@@ -965,19 +990,29 @@
       albumError.textContent = "";
       personError.textContent = "";
       var src_val = srcSel.value;
-      if (src_val === "Album" && !isValidUuidList(albumInput.value)) {
+      var albumTrim = albumInput.value.trim();
+      var personTrim = personInput.value.trim();
+      if (photoIdFieldTooLong(albumTrim)) {
+        albumError.textContent = PHOTO_ID_FIELD_TOO_LONG;
+        return;
+      }
+      if (photoIdFieldTooLong(personTrim)) {
+        personError.textContent = PHOTO_ID_FIELD_TOO_LONG;
+        return;
+      }
+      if (src_val === "Album" && !isValidUuidList(albumTrim)) {
         albumError.textContent = "Invalid UUID format";
         return;
       }
-      if (src_val === "Person" && !isValidUuidList(personInput.value)) {
+      if (src_val === "Person" && !isValidUuidList(personTrim)) {
         personError.textContent = "Invalid UUID format";
         return;
       }
       applyBtn.disabled = true;
       applyBtn.textContent = "Applying\u2026";
       post(endpoints.photo_source + "/set", { option: src_val });
-      post(endpoints.album_ids + "/set", { value: albumInput.value.trim() });
-      post(endpoints.person_ids + "/set", { value: personInput.value.trim() });
+      postTextValueSet(endpoints.album_ids + "/set", albumTrim);
+      postTextValueSet(endpoints.person_ids + "/set", personTrim);
       post(eid("button", "Apply Photo Source") + "/press").then(function () {
         applyBtn.textContent = "Applied";
         setTimeout(function () {
@@ -1745,11 +1780,12 @@
     return f;
   }
 
-  function input(type, value, placeholder) {
+  function input(type, value, placeholder, maxLength) {
     var i = document.createElement("input");
     i.type = type;
     i.value = value || "";
     if (placeholder) i.placeholder = placeholder;
+    if (maxLength != null && maxLength > 0) i.maxLength = maxLength;
     return i;
   }
 
@@ -1875,19 +1911,25 @@
           post(endpoints.photo_source + "/set", { option: p.source });
         }
         if (p.album_ids !== undefined) {
-          if (!isValidUuidList(p.album_ids)) {
+          var importAlbum = String(p.album_ids).trim();
+          if (photoIdFieldTooLong(importAlbum)) {
+            showBanner("Album IDs exceed 255 characters - not imported", "error");
+          } else if (!isValidUuidList(importAlbum)) {
             showBanner("Import skipped invalid album IDs", "error");
           } else {
-            S.album_ids = p.album_ids;
-            post(endpoints.album_ids + "/set", { value: p.album_ids });
+            S.album_ids = importAlbum;
+            postTextValueSet(endpoints.album_ids + "/set", importAlbum);
           }
         }
         if (p.person_ids !== undefined) {
-          if (!isValidUuidList(p.person_ids)) {
+          var importPerson = String(p.person_ids).trim();
+          if (photoIdFieldTooLong(importPerson)) {
+            showBanner("Person IDs exceed 255 characters - not imported", "error");
+          } else if (!isValidUuidList(importPerson)) {
             showBanner("Import skipped invalid person IDs", "error");
           } else {
-            S.person_ids = p.person_ids;
-            post(endpoints.person_ids + "/set", { value: p.person_ids });
+            S.person_ids = importPerson;
+            postTextValueSet(endpoints.person_ids + "/set", importPerson);
           }
         }
         if (p.portrait_pairing !== undefined) {


### PR DESCRIPTION
## Summary

Ports the useful behavior from PR #17 onto the current main branch without taking the older conflicting app.js changes.

- sends Album IDs and Person IDs through a form-encoded POST body instead of the query string
- keeps current main date-filter import/export behavior intact
- adds the 255-character UI/import limit and matching documentation

## Validation

- npm run docs:build

## Notes

This is intended as a conflict-free replacement path for PR #17.