### PR TITLE
Fix Immich URL save persistence and setup save UX

### DIFF
--- a/common/addon/immich_config.yaml
+++ b/common/addon/immich_config.yaml
@@ -56,6 +56,7 @@ text:
             return;
           }
           id(immich_url).publish_state(url);
+          global_preferences->sync();
           ESP_LOGI("immich", "Immich URL configured: %s", url.c_str());
           id(immich_connection_config_changed).execute();
 
@@ -77,6 +78,7 @@ text:
       - lambda: |-
           if (x.empty()) return;
           id(immich_api_key_text).publish_state(x);
+          global_preferences->sync();
           ESP_LOGI("immich", "Immich API key configured (%d chars)", x.length());
           id(immich_connection_config_changed).execute();
 

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -844,7 +844,8 @@
         nextBtn.disabled = true;
         nextBtn.textContent = "Saving\u2026";
         postTextValueSet(endpoints.immich_url + "/set", u, true)
-          .then(function () {
+          .then(function (r) {
+            if (!(r && r.ok)) throw new Error("Failed to save URL");
             return new Promise(function (r) { setTimeout(r, 500); });
           })
           .then(function () {
@@ -855,6 +856,11 @@
             S.api_key = k;
             step = 2;
             showStep();
+          })
+          .catch(function () {
+            nextBtn.disabled = false;
+            nextBtn.textContent = "Connect";
+            showBanner("Failed to save Immich URL", "error");
           });
       };
       nav.appendChild(nextBtn);

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -838,12 +838,12 @@
       var nextBtn = el("button", "btn btn-primary");
       nextBtn.textContent = "Connect";
       nextBtn.onclick = function () {
-        var u = urlInput.value.trim();
+        var u = normalizeImmichUrl(urlInput.value);
         var k = keyInput.value.trim();
         if (!u || !k) return;
         nextBtn.disabled = true;
         nextBtn.textContent = "Saving\u2026";
-        post(endpoints.immich_url + "/set", { value: u })
+        postTextValueSet(endpoints.immich_url + "/set", u, true)
           .then(function () {
             return new Promise(function (r) { setTimeout(r, 500); });
           })
@@ -942,8 +942,16 @@
     var f1 = field("Immich Server URL");
     var urlInput = input("url", S.immich_url, "http://192.168.0.1:2283");
     urlInput.onchange = function () {
-      post(endpoints.immich_url + "/set", { value: urlInput.value.trim() });
-      showSaved("URL saved");
+      var normalized = normalizeImmichUrl(urlInput.value);
+      postTextValueSet(endpoints.immich_url + "/set", normalized, true).then(function (r) {
+        if (r && r.ok) {
+          S.immich_url = normalized;
+          urlInput.value = normalized;
+          showSaved("URL saved");
+        } else {
+          showConnectionError("Failed to save URL");
+        }
+      });
     };
     f1.appendChild(urlInput);
     connBody.appendChild(f1);

--- a/docs/webserver/src/app.template.js
+++ b/docs/webserver/src/app.template.js
@@ -844,7 +844,8 @@
         nextBtn.disabled = true;
         nextBtn.textContent = "Saving\u2026";
         postTextValueSet(endpoints.immich_url + "/set", u, true)
-          .then(function () {
+          .then(function (r) {
+            if (!(r && r.ok)) throw new Error("Failed to save URL");
             return new Promise(function (r) { setTimeout(r, 500); });
           })
           .then(function () {
@@ -855,6 +856,11 @@
             S.api_key = k;
             step = 2;
             showStep();
+          })
+          .catch(function () {
+            nextBtn.disabled = false;
+            nextBtn.textContent = "Connect";
+            showBanner("Failed to save Immich URL", "error");
           });
       };
       nav.appendChild(nextBtn);

--- a/docs/webserver/src/app.template.js
+++ b/docs/webserver/src/app.template.js
@@ -838,12 +838,12 @@
       var nextBtn = el("button", "btn btn-primary");
       nextBtn.textContent = "Connect";
       nextBtn.onclick = function () {
-        var u = urlInput.value.trim();
+        var u = normalizeImmichUrl(urlInput.value);
         var k = keyInput.value.trim();
         if (!u || !k) return;
         nextBtn.disabled = true;
         nextBtn.textContent = "Saving\u2026";
-        post(endpoints.immich_url + "/set", { value: u })
+        postTextValueSet(endpoints.immich_url + "/set", u, true)
           .then(function () {
             return new Promise(function (r) { setTimeout(r, 500); });
           })
@@ -942,8 +942,16 @@
     var f1 = field("Immich Server URL");
     var urlInput = input("url", S.immich_url, "http://192.168.0.1:2283");
     urlInput.onchange = function () {
-      post(endpoints.immich_url + "/set", { value: urlInput.value.trim() });
-      showSaved("URL saved");
+      var normalized = normalizeImmichUrl(urlInput.value);
+      postTextValueSet(endpoints.immich_url + "/set", normalized, true).then(function (r) {
+        if (r && r.ok) {
+          S.immich_url = normalized;
+          urlInput.value = normalized;
+          showSaved("URL saved");
+        } else {
+          showConnectionError("Failed to save URL");
+        }
+      });
     };
     f1.appendChild(urlInput);
     connBody.appendChild(f1);


### PR DESCRIPTION
## Summary
- flush URL/API key preference writes immediately with global_preferences->sync() after publish_state
- use postTextValueSet(...) for URL saves in the setup wizard and settings page
- normalize URL before save and only show "URL saved" when the HTTP request succeeds

## Why
When users entered an Immich URL in setup, the UI could show success but the value was sometimes not durable after reboot. This change improves durability and makes save feedback accurately reflect success/failure.

## Files changed
- common/addon/immich_config.yaml
- docs/webserver/src/app.template.js
- docs/public/webserver/app.js

## Notes
- URL validation behavior remains unchanged (supports http/https; scheme normalized when omitted).