### PR TITLE
Harden Immich transient failure handling and avoid false disconnect overlays

### DIFF
--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -20,6 +20,23 @@ globals:
     initial_value: '""'
 
 script:
+  - id: immich_register_fetch_failure
+    mode: restart
+    then:
+      - lambda: |-
+          id(immich_api_retries) = 0;
+          id(immich_consecutive_failures)++;
+          if (id(immich_failure_window_started_ms) == 0) {
+            id(immich_failure_window_started_ms) = millis();
+          }
+          uint32_t cooldown_ms = 3000;
+          if (id(immich_consecutive_failures) >= 3) cooldown_ms = 7000;
+          if (id(immich_consecutive_failures) >= 6) cooldown_ms = 15000;
+          id(immich_retry_cooldown_until_ms) = millis() + cooldown_ms;
+          ESP_LOGW("immich",
+                   "Fetch failure registered; pausing fetches for %us (consecutive failures=%d)",
+                   (unsigned) (cooldown_ms / 1000), id(immich_consecutive_failures));
+
   # ---------------------------------------------------------------------------
   # Display fallback when companion portrait search fails or finds nothing
   # ---------------------------------------------------------------------------
@@ -160,6 +177,9 @@ script:
                   }
                   id(immich_fetch_started) = true;
                   id(immich_api_retries) = 0;
+                  id(immich_consecutive_failures) = 0;
+                  id(immich_failure_window_started_ms) = 0;
+                  id(immich_retry_cooldown_until_ms) = 0;
                   std::string img_url = parse_immich_asset_and_fill_slot(
                     body, id(immich_url).state, id(target_slot), id(slot0), id(slot1), id(slot2),
                     id(photo_orientation_filter).current_option());
@@ -417,30 +437,32 @@ script:
                     id(immich_last_http_status) = code;
                     clear_slot_fetch_in_flight(id(target_slot), id(slot_flags));
                     if (is_http_auth_error(code)) {
+                      if (id(immich_failure_window_started_ms) == 0) {
+                        id(immich_failure_window_started_ms) = millis();
+                      }
                       lv_label_set_text(id(connection_failed_title), "Invalid API Key");
                       lv_label_set_text(id(connection_failed_subtitle), "Check your Immich API key in\nthe espframe settings.");
+                      lv_obj_clear_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN);
+                      id(connection_failed_dim).execute();
+                      id(connection_failed_shift).execute();
+                      return;
                     } else if (is_http_retryable(code)) {
                       id(immich_api_retries)++;
                       if (id(immich_api_retries) < MAX_ERROR_RETRIES) {
                         id(immich_fetch_retry).execute();
                         return;
                       }
-                      lv_label_set_text(id(connection_failed_title), "Immich server error");
-                      lv_label_set_text(id(connection_failed_subtitle), "Your Immich server returned an error.\nIt may be restarting or under heavy load.");
-                    } else {
-                      lv_label_set_text(id(connection_failed_title), "Unable to connect to Immich");
-                      lv_label_set_text(id(connection_failed_subtitle), "Check your internet connection and\nthe health of your Immich server.");
                     }
-                    if (id(last_photo_displayed_ms) == 0) {
-                      id(last_photo_displayed_ms) = millis();
-                    }
-                    lv_obj_clear_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN);
-                    id(connection_failed_dim).execute();
-                    id(connection_failed_shift).execute();
+                    id(immich_diag_reason) = "api http status";
+                    id(log_immich_diag).execute();
+                    id(immich_register_fetch_failure).execute();
                     return;
                   }
                   id(immich_fetch_started) = true;
                   id(immich_last_http_status) = 0;
+                  id(immich_consecutive_failures) = 0;
+                  id(immich_failure_window_started_ms) = 0;
+                  id(immich_retry_cooldown_until_ms) = 0;
                   std::string orientation = id(photo_orientation_filter).current_option();
                   std::string img_url = parse_immich_asset_and_fill_slot(
                     body, id(immich_url).state, id(target_slot), id(slot0), id(slot1), id(slot2),
@@ -454,9 +476,9 @@ script:
                       return;
                     }
                     ESP_LOGW("immich", "No valid asset in response");
-                    id(immich_api_retries) = 0;
-                    id(immich_retry_cooldown_until_ms) = millis() + 30000;
-                    ESP_LOGW("immich", "No usable Immich asset; pausing fetches for 30s");
+                    id(immich_diag_reason) = "no valid asset in response";
+                    id(log_immich_diag).execute();
+                    id(immich_register_fetch_failure).execute();
                     return;
                   }
                   id(immich_api_retries) = 0;
@@ -491,22 +513,23 @@ script:
                     - script.execute: immich_fetch_retry
                   else:
                     - lambda: |-
-                        id(immich_api_retries) = 0;
-                        if (id(last_photo_displayed_ms) == 0) {
-                          id(last_photo_displayed_ms) = millis();
-                        }
-                        lv_label_set_text(id(connection_failed_title), "Unable to connect to Immich");
-                        lv_label_set_text(id(connection_failed_subtitle), "Check your internet connection and\nthe health of your Immich server.");
-                        lv_obj_clear_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN);
-                        id(immich_retry_cooldown_until_ms) = millis() + 30000;
-                        ESP_LOGW("immich", "API retries exhausted; pausing Immich fetches for 30s");
-                    - script.execute: connection_failed_dim
-                    - script.execute: connection_failed_shift
+                        id(immich_diag_reason) = "api retries exhausted";
+                        id(log_immich_diag).execute();
+                    - script.execute: immich_register_fetch_failure
 
   - id: immich_fetch_retry
     mode: restart
     then:
-      - delay: 5s
+      - lambda: |-
+          uint32_t delay_ms = 2000;
+          if (id(immich_api_retries) >= 2) delay_ms = 5000;
+          if (id(immich_api_retries) >= 3) delay_ms = 10000;
+          if (id(immich_consecutive_failures) >= 5 && delay_ms < 10000) delay_ms = 10000;
+          id(immich_api_retry_delay_ms) = delay_ms;
+          ESP_LOGW("immich", "Retrying Immich fetch in %us (attempt=%d, consecutive failures=%d)",
+                   (unsigned) (delay_ms / 1000), id(immich_api_retries) + 1,
+                   id(immich_consecutive_failures));
+      - delay: !lambda 'return id(immich_api_retry_delay_ms);'
       - script.execute: immich_fetch_into_slot
 
   # ---------------------------------------------------------------------------

--- a/common/addon/immich_config.yaml
+++ b/common/addon/immich_config.yaml
@@ -115,6 +115,9 @@ script:
           id(immich_fetch_started) = false;
           id(immich_api_retries) = 0;
           id(immich_download_retries) = 0;
+          id(immich_consecutive_failures) = 0;
+          id(immich_failure_window_started_ms) = 0;
+          id(immich_api_retry_delay_ms) = 2000;
           id(immich_last_http_status) = 0;
           id(immich_retry_cooldown_until_ms) = 0;
           id(immich_memory_fallback) = false;

--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -60,6 +60,15 @@ globals:
   - id: immich_download_retries
     type: int
     initial_value: '0'
+  - id: immich_consecutive_failures
+    type: int
+    initial_value: '0'
+  - id: immich_failure_window_started_ms
+    type: uint32_t
+    initial_value: '0'
+  - id: immich_api_retry_delay_ms
+    type: uint32_t
+    initial_value: '2000'
   - id: immich_retry_cooldown_until_ms
     type: uint32_t
     initial_value: '0'
@@ -686,8 +695,17 @@ script:
           else:
             - lambda: 'id(immich_download_retries) = 0;'
             - lambda: |-
-                id(immich_retry_cooldown_until_ms) = millis() + 30000;
-                ESP_LOGW("immich", "Download retries exhausted; pausing Immich fetches for 30s");
+                id(immich_consecutive_failures)++;
+                if (id(immich_failure_window_started_ms) == 0) {
+                  id(immich_failure_window_started_ms) = millis();
+                }
+                uint32_t cooldown_ms = 5000;
+                if (id(immich_consecutive_failures) >= 4) cooldown_ms = 10000;
+                if (id(immich_consecutive_failures) >= 8) cooldown_ms = 20000;
+                id(immich_retry_cooldown_until_ms) = millis() + cooldown_ms;
+                ESP_LOGW("immich",
+                         "Download retries exhausted; pausing fetches for %us (consecutive failures=%d)",
+                         (unsigned) (cooldown_ms / 1000), id(immich_consecutive_failures));
 
   # Start portrait pair download for the active slot (left then right or companion search)
   - id: immich_start_portrait_active

--- a/devices/guition-esp32-p4-jc1060p470/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc1060p470/device/screen_slideshow.yaml
@@ -511,6 +511,8 @@ script:
           }
           lv_obj_add_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN);
           id(last_photo_displayed_ms) = millis();
+          id(immich_failure_window_started_ms) = 0;
+          id(immich_consecutive_failures) = 0;
           id(immich_last_http_status) = 0;
 
   - id: connection_failed_dim
@@ -665,10 +667,23 @@ interval:
       - if:
           condition:
             lambda: |-
-              if (id(last_photo_displayed_ms) == 0) return false;
               if (id(backlight_paused)) return false;
               if (id(photo_source_menu_open)) return false;
-              return (millis() - id(last_photo_displayed_ms)) >= (id(connection_timeout_sec) * 1000);
+              if (id(active_slot_displayed)) return false;
+              uint32_t failure_start_ms = id(immich_failure_window_started_ms);
+              if (failure_start_ms == 0) return false;
+              if (id(immich_consecutive_failures) <= 0 && id(immich_last_http_status) == 0) return false;
+              bool image_busy = id(immich_img_0).is_downloading() ||
+                                id(immich_img_1).is_downloading() ||
+                                id(immich_img_2).is_downloading() ||
+                                id(immich_portrait_left).is_downloading() ||
+                                id(immich_portrait_right).is_downloading() ||
+                                id(immich_portrait_preload_left).is_downloading() ||
+                                id(immich_portrait_preload_right).is_downloading();
+              if (any_slot_fetch_in_flight(id(slot_flags)) || image_busy ||
+                  id(portrait).workflow_busy || id(preload_noncritical_in_flight) ||
+                  id(noncritical_remote_updates_in_flight) > 0) return false;
+              return (millis() - failure_start_ms) >= (id(connection_timeout_sec) * 1000);
           then:
             - lambda: |-
                 if (lv_obj_has_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN)) {

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -506,6 +506,8 @@ script:
           }
           lv_obj_add_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN);
           id(last_photo_displayed_ms) = millis();
+          id(immich_failure_window_started_ms) = 0;
+          id(immich_consecutive_failures) = 0;
           id(immich_last_http_status) = 0;
 
   - id: connection_failed_dim
@@ -660,10 +662,23 @@ interval:
       - if:
           condition:
             lambda: |-
-              if (id(last_photo_displayed_ms) == 0) return false;
               if (id(backlight_paused)) return false;
               if (id(photo_source_menu_open)) return false;
-              return (millis() - id(last_photo_displayed_ms)) >= (id(connection_timeout_sec) * 1000);
+              if (id(active_slot_displayed)) return false;
+              uint32_t failure_start_ms = id(immich_failure_window_started_ms);
+              if (failure_start_ms == 0) return false;
+              if (id(immich_consecutive_failures) <= 0 && id(immich_last_http_status) == 0) return false;
+              bool image_busy = id(immich_img_0).is_downloading() ||
+                                id(immich_img_1).is_downloading() ||
+                                id(immich_img_2).is_downloading() ||
+                                id(immich_portrait_left).is_downloading() ||
+                                id(immich_portrait_right).is_downloading() ||
+                                id(immich_portrait_preload_left).is_downloading() ||
+                                id(immich_portrait_preload_right).is_downloading();
+              if (any_slot_fetch_in_flight(id(slot_flags)) || image_busy ||
+                  id(portrait).workflow_busy || id(preload_noncritical_in_flight) ||
+                  id(noncritical_remote_updates_in_flight) > 0) return false;
+              return (millis() - failure_start_ms) >= (id(connection_timeout_sec) * 1000);
           then:
             - lambda: |-
                 if (lv_obj_has_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN)) {


### PR DESCRIPTION
## Summary
- add stronger retry/backoff behavior for Immich API and download failures
- gate the connection-failed overlay behind sustained real failure windows
- keep `401 Invalid API Key` feedback immediate while suppressing transient network blips
- reset failure window/counters on successful image display

## Why
Frames intermittently showed `Unable to connect to Immich` for about a second and then resumed normally. This change reduces false error overlays and hardens recovery behavior.

## Additional hardening
- progressive cooldown between repeated failures to reduce reconnect thrash
- extra guardrails around in-flight fetch/download states before declaring failure
- intended to reduce instability that can contribute to watchdog-style reboot churn under repeated failure spikes

## Validation
- compiled successfully: `builds/guition-esp32-p4-jc8012p4a1.yaml`
- validated on-device via OTA during troubleshooting
