### PR TITLE
Improve WiFi and Immich reconnect resilience

### DIFF
--- a/common/addon/connectivity.yaml
+++ b/common/addon/connectivity.yaml
@@ -29,12 +29,28 @@ http_request:
 # -----------------------------------------------------------------------------
 captive_portal:
 
+script:
+  - id: show_wifi_setup_after_disconnect
+    mode: restart
+    then:
+      - delay: 20s
+      - if:
+          condition:
+            and:
+              - not:
+                  wifi.connected:
+              - lambda: 'return !id(boot_grace_period);'
+          then:
+            - lvgl.page.show: wifi_setup_page
+            - script.execute: setup_screen_dim
+
 wifi:
   reboot_timeout: 0s
   ap:
     ssid: "${name}"
   on_connect:
     - script.stop: setup_screen_dim
+    - script.stop: show_wifi_setup_after_disconnect
     - lambda: |-
         lv_bar_set_value(id(loading_progress_bar), 100, LV_ANIM_OFF);
         lv_label_set_text(id(loading_status_label), "Connected");
@@ -61,5 +77,4 @@ wifi:
         condition:
           lambda: 'return !id(boot_grace_period);'
         then:
-          - lvgl.page.show: wifi_setup_page
-          - script.execute: setup_screen_dim
+          - script.execute: show_wifi_setup_after_disconnect

--- a/common/addon/immich_config.yaml
+++ b/common/addon/immich_config.yaml
@@ -163,11 +163,19 @@ script:
     then:
       - if:
           condition:
-            lambda: 'return is_valid_http_url(id(immich_url).state) && !id(immich_api_key_text).state.empty() && !id(immich_fetch_started);'
+            lambda: 'return is_valid_http_url(id(immich_url).state) && !id(immich_api_key_text).state.empty();'
           then:
+            - script.stop: setup_screen_dim
             - lvgl.page.show: slideshow_page
-            - lambda: 'id(target_slot) = 0;'
-            - script.execute: immich_fetch_into_slot
+            - if:
+                condition:
+                  lambda: |-
+                    if (!id(immich_fetch_started)) return true;
+                    if (id(active_slot_displayed)) return false;
+                    return !any_slot_fetch_in_flight(id(slot_flags));
+                then:
+                  - lambda: 'id(target_slot) = id(active_slot);'
+                  - script.execute: immich_fetch_into_slot
 
 button:
   - platform: restart


### PR DESCRIPTION
## Summary
- add a short grace period before showing WiFi setup after a disconnect
- cancel the pending WiFi setup transition on reconnect
- make valid Immich config return to the slideshow even after photos were already fetched
- only start a new fetch on reconnect when startup has not fetched yet, or when no active photo is displayed and no slot fetch is already in flight

## Why
A transient WiFi disconnect could switch the display to the WiFi setup page. On reconnect, `immich_check_config_ready` was gated by `!immich_fetch_started`, so once the frame had successfully fetched any photo earlier, the reconnect path became a no-op. That left the UI stuck on the setup page despite WiFi and Immich being reachable.

## Validation
- `esphome config builds\guition-esp32-p4-jc8012p4a1.yaml`
- `esphome config builds\guition-esp32-p4-jc1060p470.yaml`