### PR TITLE
Update ESPHome release to 2026.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm ci
 npm run docs:dev
 
 # Compile firmware locally
-docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.5.3 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
+docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.6.4 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
 ```
 
 ### In-Development Firmware Features

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,4 +48,4 @@ The setup wizard defaults to **24 Hour** clock format, **Europe/London (GMT+0)**
 
 - **Multiple Album, Person, or Tag IDs:** Saving comma-separated UUID lists uses a POST body so long lists no longer hit **414 URI Too Long**. Album IDs, Person IDs, and Tag IDs are still limited to **255 characters** each; see [Photo Sources](/photo-sources#album-person-and-tag-id-limits).
 - **Photo date filters:** The web UI now supports fixed date ranges and rolling ranges such as the last 6 months or last 2 years. See [Photo Sources](/photo-sources#date-filtering).
-- **ESPHome 2026.5:** Current local builds use ESPHome `2026.5.3`; manual builds also include compatibility fixes for ESPHome 2026.3 and 2026.4 LVGL changes.
+- **ESPHome 2026.6:** Current local builds use ESPHome `2026.6.4`; manual builds also include compatibility fixes for ESPHome 2026.3 and 2026.4 LVGL changes.

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -37,7 +37,7 @@ esphome run esphome.yaml
 First build takes a few minutes; OTA updates are faster.
 
 ::: info ESPHome version
-Current local builds use ESPHome `2026.5.3`. The shared configuration includes compatibility fixes for ESPHome 2026.3 and 2026.4 LVGL changes.
+Current local builds use ESPHome `2026.6.4`. The shared configuration includes compatibility fixes for ESPHome 2026.3 and 2026.4 LVGL changes.
 :::
 
 ## Substitutions

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -434,8 +434,8 @@
     "public_base_url": "https://jtenniswood.github.io/espframe",
     "release_url_base": "https://github.com/jtenniswood/espframe/releases/tag/",
     "release_workflow_actions": {
-      "checkout": "actions/checkout@v6",
-      "cache": "actions/cache@v5",
+      "checkout": "actions/checkout@v7",
+      "cache": "actions/cache@v6",
       "upload_artifact": "actions/upload-artifact@v7",
       "download_artifact": "actions/download-artifact@v8",
       "setup_node": "actions/setup-node@v6",
@@ -736,7 +736,7 @@
     "esphome_docker_image": "ghcr.io/esphome/esphome",
     "esphome_config_mount": "/config",
     "esphome_docker_remove_container": true,
-    "esphome_version": "2026.5.3"
+    "esphome_version": "2026.6.4"
   },
   "devices": [
     {


### PR DESCRIPTION
## Summary

- Update the ESPHome Docker release pin used by GitHub Actions release builds to `2026.6.4`.
- Refresh the local build command and setup docs so they match the release build version.
- Align product metadata for the GitHub Actions versions already used by the workflow files.

## Validation

- `npm run check:product`
- `python3 scripts/product_config.py github-output`
- `npm run check:all` reached the final docs build step after passing the earlier checks, but initially stopped because local dependencies were missing `vitepress`.
- `npm ci`
- `npm run docs:build`