### PR TITLE
Keep Immich searches on timeline visibility

### DIFF
--- a/components/espframe/immich_helpers.h
+++ b/components/espframe/immich_helpers.h
@@ -228,7 +228,7 @@ inline std::string build_immich_search_body(int size, bool with_people,
   // Construct the small JSON request body by hand to keep this header usable
   // from ESPHome lambdas without bringing in another JSON writer.
   std::string body = "{\"size\":" + std::to_string(size) +
-                      ",\"type\":\"IMAGE\",\"withExif\":true";
+                      ",\"type\":\"IMAGE\",\"visibility\":\"timeline\",\"withExif\":true";
   if (with_people) body += ",\"withPeople\":true";
   if (!extra.empty()) body += "," + extra;
   if (photo_source == "Favorites") {

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -181,6 +181,8 @@ static void test_immich_body_helpers() {
   assert(pick_one_uuid_from_csv(" a, b ,, c ") == "a");
   assert(build_immich_search_body(1, true, "Favorites", "", "", "").find("\"isFavorite\":true") !=
          std::string::npos);
+  assert(build_immich_search_body(1, true, "All Photos", "", "", "").find("\"visibility\":\"timeline\"") !=
+         std::string::npos);
   assert(build_immich_search_body(1, false, "Person", "", "p1,p2", "").find("\"personIds\":[\"p1\"]") !=
          std::string::npos);
   assert(build_immich_search_body(1, false, "Tag", "", "", "t1,t2").find("\"tagIds\":[\"t1\",\"t2\"]") !=


### PR DESCRIPTION
## Summary
- Pin Immich random search requests to timeline visibility for Immich v3 compatibility
- Add a helper test assertion for the search request body

## Checks
- `npm run test:helpers`
- `npm run check:compat`

## Notes
- `npm run check:product` currently fails on unrelated workflow-version expectations for `actions/checkout@v6` and `actions/cache@v5`.