### PR TITLE
Require pull request merge flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## What changes when merged
+
+- 
+
+## Device testing
+
+- [ ] Not needed for this change
+- [ ] Tested on device
+- [ ] Needs device testing before merge
+
+## Notes for reviewers
+
+- 

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -1,0 +1,10 @@
+# Repository Governance
+
+Changes to `main` must go through pull requests. The protected branch rule for
+`main` requires a pull request before merging, applies to administrators, blocks
+force pushes and branch deletion, and requires review conversations to be
+resolved before merge.
+
+Pull requests are merged with squash merge only. The squash commit message uses
+the pull request title and description, so the pull request description should
+explain what changes when the pull request is merged.


### PR DESCRIPTION
## What changes when merged

- Protects `main` so changes must come through a pull request before they can be merged.
- Records the repository governance policy in the docs so the expected merge flow is visible in the repo.
- Adds a pull request template with a required summary section for what changes when the PR is merged.

## Device testing

- [x] Not needed for this change
- [ ] Tested on device
- [ ] Needs device testing before merge

## Notes for reviewers

- GitHub settings were applied directly: direct pushes to `main` are blocked, admins are included, force pushes and deletion are disabled, review conversations must be resolved, and only squash merge is enabled.
- Squash merge messages now use the pull request title and description, so each merged PR keeps the change description in history.