### PR TITLE
Fix Album startup after OTA

### DIFF
--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -307,16 +307,22 @@ script:
       - if:
           condition:
             lambda: |-
-              std::string source = id(photo_source_select).current_option();
               return id(immich_url).state.empty() ||
                      id(immich_api_key_text).state.empty() ||
-                     (source == "Album" && id(immich_album_ids).state.empty()) ||
-                     (source == "Person" && id(immich_person_ids).state.empty()) ||
-                     (source == "Tag" && id(immich_tag_ids).state.empty());
+                     !immich_source_has_required_ids(
+                       id(photo_source_select).current_option(),
+                       id(immich_album_ids).state,
+                       id(immich_person_ids).state,
+                       id(immich_tag_ids).state);
           then:
             - lambda: |-
                 ESP_LOGW("immich", "Metadata source selected but Immich URL, API key, or source IDs are missing");
                 clear_slot_fetch_in_flight(id(target_slot), id(slot_flags));
+            - if:
+                condition:
+                  lambda: 'return !id(active_slot_displayed);'
+                then:
+                  - script.execute: immich_retry_config_ready
             - script.stop: immich_fetch_metadata_into_slot
       - http_request.post:
           id: http_req

--- a/common/addon/immich_config.yaml
+++ b/common/addon/immich_config.yaml
@@ -173,12 +173,33 @@ script:
             - if:
                 condition:
                   lambda: |-
+                    return !immich_source_has_required_ids(
+                      id(photo_source_select).current_option(),
+                      id(immich_album_ids).state,
+                      id(immich_person_ids).state,
+                      id(immich_tag_ids).state);
+                then:
+                  - logger.log:
+                      level: DEBUG
+                      tag: immich
+                      format: "Photo source is waiting for restored source IDs"
+                  - script.execute: immich_retry_config_ready
+                  - script.stop: immich_check_config_ready
+            - if:
+                condition:
+                  lambda: |-
                     if (!id(immich_fetch_started)) return true;
                     if (id(active_slot_displayed)) return false;
                     return !any_slot_fetch_in_flight(id(slot_flags));
                 then:
                   - lambda: 'id(target_slot) = id(active_slot);'
                   - script.execute: immich_fetch_into_slot
+
+  - id: immich_retry_config_ready
+    mode: restart
+    then:
+      - delay: 2s
+      - script.execute: immich_check_config_ready
 
 button:
   - platform: restart

--- a/common/addon/immich_filter.yaml
+++ b/common/addon/immich_filter.yaml
@@ -334,6 +334,21 @@ script:
   - id: flush_slots_and_refetch
     mode: single
     then:
+      - if:
+          condition:
+            lambda: |-
+              return !immich_source_has_required_ids(
+                id(photo_source_select).current_option(),
+                id(immich_album_ids).state,
+                id(immich_person_ids).state,
+                id(immich_tag_ids).state);
+          then:
+            - logger.log:
+                level: DEBUG
+                tag: immich
+                format: "Photo source apply deferred until source IDs are restored"
+            - script.execute: immich_retry_config_ready
+            - script.stop: flush_slots_and_refetch
       - lambda: |-
           id(slot0).ready = false;
           id(slot1).ready = false;

--- a/components/espframe/immich_helpers.h
+++ b/components/espframe/immich_helpers.h
@@ -240,6 +240,19 @@ inline std::string build_uuid_json_array(const std::string &csv) {
   return result;
 }
 
+inline bool immich_source_has_required_ids(const std::string &photo_source,
+                                           const std::string &album_ids,
+                                           const std::string &person_ids,
+                                           const std::string &tag_ids) {
+  if (photo_source == "Album")
+    return !split_uuid_csv(album_ids).empty();
+  if (photo_source == "Person")
+    return !split_uuid_csv(person_ids).empty();
+  if (photo_source == "Tag")
+    return !split_uuid_csv(tag_ids).empty();
+  return true;
+}
+
 inline std::string build_immich_search_body(int size, bool with_people,
                                              const std::string &photo_source,
                                              const std::string &album_ids,

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -178,6 +178,15 @@ static void test_immich_body_helpers() {
          "\"takenBefore\":\"2024-05-10T23:59:59.999Z\"");
 
   assert(build_uuid_json_array(" a, b ,, c ") == "[\"a\",\"b\",\"c\"]");
+  assert(immich_source_has_required_ids("All Photos", "", "", ""));
+  assert(immich_source_has_required_ids("Favorites", "", "", ""));
+  assert(immich_source_has_required_ids("Memories", "", "", ""));
+  assert(immich_source_has_required_ids("Album", " a ", "", ""));
+  assert(!immich_source_has_required_ids("Album", " , ", "", ""));
+  assert(immich_source_has_required_ids("Person", "", " p1 ", ""));
+  assert(!immich_source_has_required_ids("Person", "", "", ""));
+  assert(immich_source_has_required_ids("Tag", "", "", " t1,t2 "));
+  assert(!immich_source_has_required_ids("Tag", "", "", " , "));
   assert(pick_one_uuid_from_csv(" a, b ,, c ") == "a");
   int album_order_index = 0;
   assert(pick_album_id_for_metadata_search(" a, b, c ", "Album list order", album_order_index) == "a");


### PR DESCRIPTION
## Summary
- Wait for restored Album/Person/Tag IDs before boot fetches start for those sources.
- Stop treating “screen schedule enabled but time not synced yet” as a reason to keep the display off.
- Recover the display and restart Immich when the reset reason reports an ESPHome OTA reboot.
- Restart the normal Immich startup check after a manual screen wake, so a blank first slot can load content.

## Root cause
The device log showed `Fetch paused (backlight off)` immediately after an ESPHome OTA reboot, followed by reset reason `Reboot request from esphome.ota`. The native ESPHome OTA path was not running the HTTP firmware updater recovery path, and the screen schedule boot guard could keep `backlight_paused` true while time was not yet synced. While that flag was true, Immich fetches stopped before loading the first photo. Manual wake then only ran the prefetch path, which does nothing when no active photo has ever been displayed.

## Validation
- npm run test:firmware-logic
- npm run check:fast
- esphome config builds/guition-esp32-p4-jc8012p4a1.yaml
