### PR TITLE
Recover display after ESPHome OTA

### DIFF
--- a/common/addon/backlight.yaml
+++ b/common/addon/backlight.yaml
@@ -37,8 +37,7 @@ light:
         - if:
             condition:
               lambda: |-
-                return id(screen_schedule_asleep) ||
-                       (id(schedule_enabled).state && !id(sntp_time).now().is_valid());
+                return id(screen_schedule_asleep);
             then:
               - script.execute: backlight_force_display_off
             else:

--- a/common/addon/backlight_schedule.yaml
+++ b/common/addon/backlight_schedule.yaml
@@ -218,13 +218,13 @@ text_sensor:
 # =============================================================================
 
 script:
-  # Keep the backlight dark after reboot until valid time confirms the schedule.
+  # Preserve an already-asleep schedule state across normal reboots.
   - id: screen_schedule_boot_guard
     mode: restart
     then:
       - if:
           condition:
-            switch.is_on: schedule_enabled
+            lambda: 'return id(schedule_enabled).state && id(screen_schedule_asleep);'
           then:
             - globals.set:
                 id: backlight_paused
@@ -445,8 +445,7 @@ script:
             lambda: |-
               auto now = id(sntp_time).now();
               return id(backlight_paused) || id(screen_schedule_asleep) ||
-                     id(backlight_manual_off) ||
-                     (id(schedule_enabled).state && !now.is_valid());
+                     id(backlight_manual_off);
           then:
             - script.execute: backlight_force_display_off
           else:
@@ -549,7 +548,6 @@ script:
           condition:
             lambda: |-
               auto now = id(sntp_time).now();
-              if (id(schedule_enabled).state && !now.is_valid()) return true;
               if (id(backlight_paused) || id(screen_schedule_asleep) ||
                   id(screensaver_display_off_active) ||
                   !id(backlight).current_values.is_on()) {
@@ -577,15 +575,6 @@ script:
                 if (was_off) {
                   id(touch_started_while_off) = true;
                   id(wake_touch_ms) = millis();
-                }
-
-                if (id(schedule_enabled).state && !now.is_valid()) {
-                  id(backlight_paused) = true;
-                  id(screensaver_display_off_active) = true;
-                  id(screen_schedule_asleep) = true;
-                  id(backlight_manual_off) = false;
-                  id(manual_wake_ms) = 0;
-                  return;
                 }
 
                 id(backlight_manual_off) = false;
@@ -617,22 +606,16 @@ script:
                 }
             - if:
                 condition:
-                  lambda: 'return id(schedule_enabled).state && !id(sntp_time).now().is_valid();'
+                  lambda: 'return id(manual_wake_ms) != 0;'
                 then:
-                  - script.execute: backlight_schedule_display_off
+                  - script.execute: screen_schedule_wake_timeout_check
                 else:
-                  - if:
-                      condition:
-                        lambda: 'return id(manual_wake_ms) != 0;'
-                      then:
-                        - script.execute: screen_schedule_wake_timeout_check
-                      else:
-                        - script.stop: screen_schedule_wake_timeout_check
-                  - lvgl.resume:
-                  - script.execute: screen_schedule_restore_page
-                  - delay: 50ms
-                  - script.execute: backlight_apply_brightness
-                  - script.execute: immich_prefetch_chain
+                  - script.stop: screen_schedule_wake_timeout_check
+            - lvgl.resume:
+            - script.execute: screen_schedule_restore_page
+            - delay: 50ms
+            - script.execute: backlight_apply_brightness
+            - script.execute: immich_check_config_ready
 
   # Backward-compatible script name used by older local call sites.
   - id: backlight_check_schedule
@@ -687,7 +670,6 @@ interval:
           condition:
             lambda: |-
               return id(screen_schedule_asleep) ||
-                     id(backlight_manual_off) ||
-                     (id(schedule_enabled).state && !id(sntp_time).now().is_valid());
+                     id(backlight_manual_off);
           then:
             - script.execute: backlight_force_display_off

--- a/common/addon/firmware_update.yaml
+++ b/common/addon/firmware_update.yaml
@@ -40,6 +40,28 @@ globals:
     type: bool
     initial_value: 'false'
 
+script:
+  - id: firmware_update_recover_display
+    mode: restart
+    then:
+      - script.stop: screen_schedule_sleep
+      - script.stop: backlight_schedule_display_off
+      - script.stop: screen_schedule_wake_timeout_check
+      - lambda: |-
+          id(backlight_manual_off) = false;
+          id(screen_schedule_asleep) = false;
+          id(screensaver_display_off_active) = false;
+          id(backlight_paused) = false;
+          id(manual_wake_ms) = 0;
+          global_preferences->sync();
+          ESP_LOGI("firmware", "Recovered display state after firmware update");
+      - lvgl.resume:
+      - script.execute: screen_schedule_restore_page
+      - delay: 100ms
+      - script.execute: backlight_apply_brightness
+      - delay: 2s
+      - script.execute: immich_connection_config_changed
+
 # -----------------------------------------------------------------------------
 # OTA and HTTP update sources (stable + beta manifest)
 # -----------------------------------------------------------------------------

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -80,8 +80,16 @@ debug:
 text_sensor:
   - platform: debug
     reset_reason:
+      id: reset_reason_sensor
       name: "Reset Reason"
       entity_category: diagnostic
+      on_value:
+        then:
+          - if:
+              condition:
+                lambda: 'return x.find("esphome.ota") != std::string::npos;'
+              then:
+                - script.execute: firmware_update_recover_display
 
 json:
 

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_loading.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_loading.yaml
@@ -114,8 +114,7 @@ esphome:
             condition:
               lambda: |-
                 return !id(backlight_manual_off) &&
-                       !id(screen_schedule_asleep) &&
-                       !(id(schedule_enabled).state && !id(sntp_time).now().is_valid());
+                       !id(screen_schedule_asleep);
             then:
               - light.turn_on:
                   id: backlight

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -560,8 +560,7 @@ script:
       - if:
           condition:
             lambda: |-
-              return id(screen_schedule_asleep) ||
-                     (id(schedule_enabled).state && !id(sntp_time).now().is_valid());
+              return id(screen_schedule_asleep);
           then:
             - script.execute: backlight_force_display_off
           else:


### PR DESCRIPTION
## Summary
- Stop treating “screen schedule enabled but time not synced yet” as a reason to keep the display off.
- Recover the display and restart Immich when the reset reason reports an ESPHome OTA reboot.
- Restart the normal Immich startup check after a manual screen wake, so a blank first slot can load content.

## Root cause
The device log showed `Fetch paused (backlight off)` immediately after an ESPHome OTA reboot, followed by reset reason `Reboot request from esphome.ota`. The schedule boot guard could keep `backlight_paused` true while time was not yet synced, so Immich fetches stopped before loading the first photo. Manual wake only ran the prefetch path, which does nothing when no active photo has ever been displayed.

## Validation
- npm run test:firmware-logic
- npm run check:fast
- esphome config builds/guition-esp32-p4-jc8012p4a1.yaml
