### PR TITLE
Fix JD9365 panel timing for Guition display

### DIFF
--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -176,6 +176,15 @@ display:
     auto_clear_enabled: false
     update_interval: never
     color_order: RGB
+    # Match Guition's JD9365 reference driver for the JC8012P4A1C_I_W_Y panel.
+    pclk_frequency: 60MHz
+    lane_bit_rate: 1500Mbps
+    hsync_pulse_width: 20
+    hsync_back_porch: 20
+    hsync_front_porch: 40
+    vsync_pulse_width: 4
+    vsync_back_porch: 8
+    vsync_front_porch: 20
     dimensions:
       width: 800
       height: 1280


### PR DESCRIPTION
## Summary
- Explicitly pin the JC8012P4A1/JD9365 MIPI DSI timing to Guition reference values.
- Raise the DSI lane rate to 1500 Mbps for the JC8012P4A1C_I_W_Y panel.
- Leave the existing ESPHome panel model, init sequence, and touch setup unchanged.

## Why
Issue #106 reports that touch now works on newer JC8012P4A1C_I_W_Y hardware, but the screen still shows a grey or garbled band. The changing pattern points to the image pipeline running while the panel scanout timing is wrong.

## Research
- Guition's P4-series JD9365 reference driver uses 60 MHz pclk, 1500 Mbps lane rate, hsync 20/20/40, and vsync 4/8/20 for the 800x1280 panel.
- ESPHome 2026.6.4 already has matching porch timing for the built-in model, but defaults to a lower lane rate, so this config now pins the vendor values explicitly.

Refs #106

## Testing
- Passed `npm run check:fast`.
- Passed ESPHome config validation for `builds/guition-esp32-p4-jc8012p4a1.factory.yaml`.
- Full ESPHome compile was attempted and progressed through app, MIPI DSI, ESP-IDF, and LVGL compilation, but this laptop ran out of disk space while archiving LVGL. Local free space was about 1.3 GB at failure, so this is an environment limitation rather than a config failure.
