### PR TITLE
Validate pull requests with CI gate

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,26 +1,18 @@
-name: Compile Check
+name: PR Validation
 
 on:
   pull_request:
-    paths:
-      - "components/**"
-      - "common/**"
-      - "devices/guition-esp32-p4-jc8012p4a1/**"
-      - "builds/**"
-      - "docs/**"
-      - "package.json"
-      - "package-lock.json"
-      - "product/**"
-      - "scripts/**"
-      - "tests/**"
-      - ".agents/**"
-      - ".github/workflows/**"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -5,6 +5,12 @@ Changes to `main` must go through pull requests. The protected branch rule for
 force pushes and branch deletion, and requires review conversations to be
 resolved before merge.
 
+The protected branch rule should also require the `Validate PR Gate` and
+`Compile Firmware` status checks from the `PR Validation` workflow before a pull
+request can merge. Those checks run for every pull request, so documentation-only
+and maintenance changes still get a clear merge gate instead of silently skipping
+CI.
+
 Pull requests are merged with squash merge only. The squash commit message uses
 the pull request title and description, so the pull request description should
 explain what changes when the pull request is merged.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,7 @@ Before opening a pull request, run:
 npm run check:pr
 ```
 
-This is the normal confidence check for feature branches. It verifies generated files, product metadata, backup compatibility, web UI behavior, firmware helper logic, timezone data, and the documentation build.
+This is the normal confidence check for feature branches. It verifies generated files, product metadata, backup compatibility, web UI behavior, firmware helper logic, timezone data, and the documentation build. GitHub runs this automatically on every pull request as the `Validate PR Gate` check.
 
 Before publishing a firmware release, run:
 
@@ -56,7 +56,7 @@ This group compiles and runs host-side C++ tests for firmware helper logic, then
 
 ### Full Firmware Compile
 
-The pull request workflow compiles the 10-inch P4 factory firmware after the PR checks pass. To run the same type of compile locally with Docker:
+The pull request workflow compiles the 10-inch P4 factory firmware after the PR checks pass. GitHub runs this automatically on every pull request as the `Compile Firmware` check. To run the same type of compile locally with Docker:
 
 ```sh
 docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.6.4 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -796,24 +796,11 @@
       "release": { "contents": "write" }
     },
     "github_workflow_names": {
-      "compile": "Compile Check",
+      "compile": "PR Validation",
       "docs": "Deploy Docs",
       "release": "Build Release"
     },
     "github_workflow_path_filters": {
-      "compile_pull_request": [
-        "components/**",
-        "common/**",
-        "devices/guition-esp32-p4-jc8012p4a1/**",
-        "builds/**",
-        "docs/**",
-        "package.json",
-        "package-lock.json",
-        "product/**",
-        "scripts/**",
-        "tests/**",
-        ".github/workflows/**"
-      ],
       "docs_push": [
         "docs/**",
         "product/**",
@@ -825,7 +812,7 @@
       ]
     },
     "github_workflow_events": {
-      "compile": ["pull_request"],
+      "compile": ["pull_request", "workflow_dispatch"],
       "docs": ["push", "workflow_run", "workflow_dispatch"],
       "release": ["release", "workflow_dispatch"]
     },

--- a/scripts/product_contract/project_release_metadata.py
+++ b/scripts/product_contract/project_release_metadata.py
@@ -82,7 +82,7 @@ def check_project_release_metadata(product: dict, errors: list[str]) -> None:
             if not label:
                 errors.append(f"project.github_workflow_names.{name or '<missing>'} must be a non-empty string")
     workflow_path_filters = project.get("github_workflow_path_filters", {})
-    expected_path_filter_sets = {"compile_pull_request", "docs_push"}
+    expected_path_filter_sets = {"docs_push"}
     if not isinstance(workflow_path_filters, dict) or not workflow_path_filters:
         errors.append("project.github_workflow_path_filters must be a non-empty object")
     else:

--- a/scripts/product_contract/workflows.py
+++ b/scripts/product_contract/workflows.py
@@ -449,13 +449,6 @@ def check_device_workflow_contract(product: dict, errors: list[str]) -> None:
                 ".github/workflows/compile.yml",
                 errors,
             )
-        if device_dir:
-            require_contains(
-                compile_workflow,
-                f'"{device_dir}/**"',
-                ".github/workflows/compile.yml",
-                errors,
-            )
         public_manifest_dirs = []
         for field in ("public_manifest", "public_beta_manifest"):
             public_manifest = str(devices_by_slug.get(slug, {}).get(field, "")).strip()
@@ -545,7 +538,6 @@ def check_esphome_version(product: dict, errors: list[str]) -> None:
 
 def check_workflows(product: dict, errors: list[str]) -> None:
     compile_workflow = read(ROOT / ".github" / "workflows" / "compile.yml", errors)
-    require_contains(compile_workflow, '"product/**"', ".github/workflows/compile.yml", errors)
 
     docs_workflow = read(ROOT / ".github" / "workflows" / "docs.yml", errors)
     release_workflow = read(ROOT / ".github" / "workflows" / "release.yml", errors)
@@ -554,9 +546,6 @@ def check_workflows(product: dict, errors: list[str]) -> None:
         require_contains(docs_workflow, f"branches: [{default_branch}]", ".github/workflows/docs.yml", errors)
     workflow_path_filters = product["project"].get("github_workflow_path_filters", {})
     if isinstance(workflow_path_filters, dict):
-        for path in workflow_path_filters.get("compile_pull_request", []):
-            if isinstance(path, str) and path.strip():
-                require_workflow_path_filter(compile_workflow, path.strip(), ".github/workflows/compile.yml", errors)
         for path in workflow_path_filters.get("docs_push", []):
             if isinstance(path, str) and path.strip():
                 require_workflow_path_filter(docs_workflow, path.strip(), ".github/workflows/docs.yml", errors)


### PR DESCRIPTION
## What changes when merged

- Rename the existing compile workflow to `PR Validation` and run it for every pull request.
- Keep the two merge-gate jobs: `Validate PR Gate` for fast project checks and `Compile Firmware` for the ESPHome factory firmware compile.
- Add manual workflow dispatch and cancel stale runs when a PR branch is updated.
- Update workflow metadata and docs so the protected branch can require the right checks before merge.

## Device testing

- [x] Not needed for this change
- [ ] Tested on device
- [ ] Needs device testing before merge

## Verification

- `npm run check:pr` passed locally.
- Workflow YAML parsed locally.
- `npm run check:product` passed locally.
- GitHub `Validate PR Gate` passed.
- GitHub `Compile Firmware` passed.
- Local Docker firmware compile could not start because Docker Desktop returned a metadata I/O error before ESPHome ran; GitHub Actions completed the same firmware compile successfully.

## Notes for reviewers

- Current `main` branch protection does not require status checks yet. After this PR lands, require `Validate PR Gate` and `Compile Firmware` on `main`.