### PR TITLE
fix: memories fetch fails against Immich >=3.0.3 (date format)

### DIFF
--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -72,7 +72,9 @@ script:
             auto now = id(sntp_time).now();
             std::string day = immich_format_iso_date_offset(
               now.year, now.month, now.day_of_month, id(immich_request_state).memory_window_offset);
-            return id(immich_url).state + "/api/memories?type=on_this_day&for=" + day + "T00:00:00.000Z";
+            // Immich >=3.0.3 (PR #29907) tightened /api/memories `for` validation to
+            // date-only (YYYY-MM-DD); a full ISO datetime now fails schema validation.
+            return id(immich_url).state + "/api/memories?type=on_this_day&for=" + day;
           capture_response: true
           max_response_buffer_size: 192kB
           request_headers:


### PR DESCRIPTION
## Summary

Fixes the `Memories` photo source silently falling back to random photos against Immich **>=3.0.3**.

Immich [PR #29907](https://github.com/immich-app/immich/pull/29907) ("fix: memory search date validation", shipped in v3.0.3) tightened the `for` query parameter on `GET /api/memories` to require a bare `YYYY-MM-DD` date. A full ISO datetime (`YYYY-MM-DDT00:00:00.000Z`), which this firmware has always sent, now fails schema validation with HTTP 400:

```json
{"message":"Validation failed","errors":[{"path":["for"],"message":"Invalid input: expected ISO date string (YYYY-MM-DD), received string"}]}
```

Since every request in the day-window scan (`today ± 2 days`) fails the same way, the memories fetch always finds zero results and silently falls back to the random photo source — with no visible error to the user, just "memories" quietly not showing up.

## Fix

Drop the unnecessary `T00:00:00.000Z` suffix. The `day` string built by `immich_format_iso_date_offset` is already `YYYY-MM-DD` — no other change needed.

## Verification

Confirmed against a live Immich 3.0.3 instance:
- Before: `GET /api/memories?type=on_this_day&for=2026-07-19T00:00:00.000Z` → `400`
- After: `GET /api/memories?type=on_this_day&for=2026-07-19` → `200`, correct memory data returned

Also verified on-device via serial debug trace (temporary logging, since reverted) that the full fetch → parse → display pipeline runs cleanly end-to-end against a live server with this change — real `200` responses, correct JSON parsing, and correct empty-result fallback behavior when a given day genuinely has no memories.

This does **not** touch the `takenAfter`/`takenBefore` params used elsewhere in this file (e.g. `search/metadata` date filtering) — that's a different endpoint, unaffected by immich-app/immich#29907, and still expects the full datetime format.
