### PR TITLE
fix: memories fetch aborts the device on constrained DRAM

### DIFF
--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -73,8 +73,11 @@ script:
             std::string day = immich_format_iso_date_offset(
               now.year, now.month, now.day_of_month, id(immich_request_state).memory_window_offset);
             return id(immich_url).state + "/api/memories?type=on_this_day&for=" + day + "T00:00:00.000Z";
-          capture_response: true
-          max_response_buffer_size: 192kB
+          # Deliberately no capture_response: an on_this_day response can reach
+          # tens or hundreds of kB depending on how many memories the library
+          # holds for that day, and capture_response copies the whole body into a
+          # std::string, which allocates from internal DRAM. The body is streamed
+          # into the filtered parser below instead. See on_response.
           request_headers:
             Accept: application/json
             x-api-key: !lambda 'return id(immich_api_key_text).state.c_str();'
@@ -91,9 +94,69 @@ script:
                   filter[0]["assets"][0]["id"] = true;
                   filter[0]["assets"][0]["type"] = true;
 
+                  // Pulls the response straight off the HTTP container in 512B
+                  // chunks so the body is never held in memory in full. Only the
+                  // filtered document survives, and that stays a few kB no matter
+                  // how large the response is. HttpContainer::read() does not have
+                  // BSD socket semantics (0 means "nothing yet" OR "all read", <0
+                  // is an error), so completion goes through http_read_loop_result.
+                  struct MemoriesStreamReader {
+                    esphome::http_request::HttpContainer *container;
+                    uint32_t last_data_time;
+                    uint32_t read_timeout;
+                    uint8_t buf[512];
+                    size_t buf_len{0};
+                    size_t buf_pos{0};
+                    bool eof{false};
+
+                    bool fill() {
+                      if (this->buf_pos < this->buf_len) return true;
+                      if (this->eof) return false;
+                      this->buf_pos = 0;
+                      this->buf_len = 0;
+                      while (true) {
+                        int r = this->container->read(this->buf, sizeof(this->buf));
+                        esphome::App.feed_wdt();
+                        esphome::yield();
+                        auto res = esphome::http_request::http_read_loop_result(
+                          r, this->last_data_time, this->read_timeout,
+                          this->container->is_read_complete());
+                        if (res == esphome::http_request::HttpReadLoopResult::RETRY) continue;
+                        if (res != esphome::http_request::HttpReadLoopResult::DATA) {
+                          this->eof = true;
+                          return false;
+                        }
+                        this->buf_len = (size_t) r;
+                        return true;
+                      }
+                    }
+
+                    int read() {
+                      if (!this->fill()) return -1;
+                      return this->buf[this->buf_pos++];
+                    }
+
+                    size_t readBytes(char *dst, size_t len) {
+                      size_t n = 0;
+                      while (n < len) {
+                        if (!this->fill()) break;
+                        size_t take = std::min(this->buf_len - this->buf_pos, len - n);
+                        memcpy(dst + n, this->buf + this->buf_pos, take);
+                        this->buf_pos += take;
+                        n += take;
+                      }
+                      return n;
+                    }
+                  };
+
+                  MemoriesStreamReader reader;
+                  reader.container = response.get();
+                  reader.last_data_time = millis();
+                  reader.read_timeout = id(http_req)->get_timeout();
+
                   JsonDocument doc;
                   DeserializationError err = deserializeJson(
-                    doc, body.c_str(), DeserializationOption::Filter(filter));
+                    doc, reader, DeserializationOption::Filter(filter));
                   if (err || !doc.is<JsonArray>()) {
                     ESP_LOGD("immich", "No memories for offset %+d", id(immich_request_state).memory_window_offset);
                     return;
@@ -128,10 +191,9 @@ script:
                     return;
                   }
 
-                  int pick = rand() % id(immich_request_state).memory_image_count;
-                  id(immich_request_state).select_memory_image(pick);
-                  ESP_LOGD("immich", "Memory picked: %s (%d of %d across today +/- 2 days)",
-                           id(immich_request_state).memory_asset_id.c_str(), pick + 1, id(immich_request_state).memory_image_count);
+                  // memory_asset_id already holds the sampled pick.
+                  ESP_LOGD("immich", "Memory picked: %s (1 of %d across today +/- 2 days)",
+                           id(immich_request_state).memory_asset_id.c_str(), id(immich_request_state).memory_image_count);
                   id(immich_fetch_memory_asset).execute();
           on_error:
             then:
@@ -148,8 +210,7 @@ script:
                     id(immich_fetch_into_slot).execute();
                     return;
                   }
-                  int pick = rand() % id(immich_request_state).memory_image_count;
-                  id(immich_request_state).select_memory_image(pick);
+                  // memory_asset_id already holds the sampled pick.
                   id(immich_fetch_memory_asset).execute();
 
   # ---------------------------------------------------------------------------

--- a/components/espframe/immich_helpers.h
+++ b/components/espframe/immich_helpers.h
@@ -25,7 +25,6 @@ struct ImmichRequestState {
   bool memory_fallback = false;
   std::string memory_asset_id;
   int memory_window_offset = -2;
-  std::string memory_image_ids;
   int memory_image_count = 0;
 
   std::string metadata_album_id;
@@ -42,7 +41,6 @@ struct ImmichRequestState {
     this->memory_fallback = false;
     this->memory_asset_id.clear();
     this->memory_window_offset = -2;
-    this->memory_image_ids.clear();
     this->memory_image_count = 0;
   }
 
@@ -51,25 +49,20 @@ struct ImmichRequestState {
     return this->memory_window_offset <= 2;
   }
 
+  // Reservoir sampling (Algorithm R, k=1): keep one candidate and replace it with
+  // probability 1/n as each asset is seen. Collecting every id first and indexing
+  // into the collection afterwards needs memory proportional to the window size —
+  // a five-day window can hold several hundred assets, which is a ~15kB string
+  // grown by repeated reallocation, and each reallocation needs the old and new
+  // buffers alive at the same time. That aborts on devices whose largest free
+  // internal-DRAM block is smaller than the pair. This is O(1) and picks
+  // uniformly, exactly as selecting a random index into the full list did.
   void add_memory_image(const std::string &asset_id) {
     if (asset_id.empty()) return;
-    if (!this->memory_image_ids.empty()) this->memory_image_ids += ",";
-    this->memory_image_ids += asset_id;
     this->memory_image_count++;
-  }
-
-  bool select_memory_image(int index) {
-    if (index < 0 || index >= this->memory_image_count) return false;
-    size_t start = 0;
-    for (int i = 0; i < index; i++) {
-      start = this->memory_image_ids.find(',', start);
-      if (start == std::string::npos) return false;
-      start++;
+    if (esp_random() % static_cast<uint32_t>(this->memory_image_count) == 0) {
+      this->memory_asset_id = asset_id;
     }
-    size_t end = this->memory_image_ids.find(',', start);
-    if (end == std::string::npos) end = this->memory_image_ids.size();
-    this->memory_asset_id = this->memory_image_ids.substr(start, end - start);
-    return !this->memory_asset_id.empty();
   }
 
   bool cooldown_active(uint32_t now_ms) const {

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -283,13 +283,18 @@ static void test_immich_request_state() {
 
   state.begin_memory_search();
   assert(state.memory_window_offset == -2);
+  assert(state.memory_asset_id.empty());
   state.add_memory_image("asset-a");
+  assert(state.memory_image_count == 1);
+  assert(state.memory_asset_id == "asset-a");
   state.add_memory_image("");
+  assert(state.memory_image_count == 1);
   state.add_memory_image("asset-b");
   assert(state.memory_image_count == 2);
-  assert(state.select_memory_image(1));
+  // One candidate is kept and replaced with probability 1/n; the stubbed
+  // esp_random() always returns zero, so every replacement roll succeeds and the
+  // most recent asset wins.
   assert(state.memory_asset_id == "asset-b");
-  assert(!state.select_memory_image(2));
   assert(state.advance_memory_window());
   assert(state.memory_window_offset == -1);
 


### PR DESCRIPTION
# fix: memories fetch aborts the device on constrained DRAM

## Summary

Two allocation sites in the memories pipeline size themselves off the response
rather than off a bound, and abort the device when internal DRAM cannot satisfy
them. Both are fixed here without changing behaviour.

On the Guition ESP32-P4 (`jc8012p4a1`) the internal DRAM heap runs with roughly
50-90kB free and a **21-30kB largest contiguous block**. C++ exceptions are
disabled in this build, so an allocation `operator new` cannot satisfy does not
throw — it aborts and reboots the device.

> The byte counts below are measurements from the one library this was
> reproduced against. They are illustrative of how the allocations scale, not
> fixed sizes — `/api/memories` returns however many assets that library happens
> to hold for the date window, so a smaller library produces a much smaller
> response and may never come near the limit. What matters is that neither
> allocation is bounded, so whether a given device aborts depends on library
> size rather than on anything the firmware controls.

## The two failures

**1. The response body is copied into DRAM.** `capture_response: true` makes
`HttpRequestSendAction::play()` stage the body in a PSRAM buffer and then copy it
into a `std::string`, which allocates from internal DRAM. The response scales
with how many memories exist for that day, and on the library tested here a
single day reached **80,484 bytes** — well past what this heap can hand out in
one block.

```
abort <- __cxa_allocate_exception <- operator new
     <- std::string::reserve <- HttpRequestSendAction::play
```

The parser only keeps `id` and `type`, so the body never needs to exist in memory
in full. It is now streamed off the `HttpContainer` in 512B chunks through a
duck-typed ArduinoJson reader. Neither the PSRAM staging buffer nor the DRAM
string is allocated, and the filtered document stays a few kB no matter how large
the response is.

**2. Every asset id is accumulated to pick one.** `add_memory_image()` appended
each matching id to one `std::string` so a random index could be taken at the
end, so the string grows in proportion to the window. On the library tested here
the five-day window held **350+ assets, roughly 15kB**. `std::string` grows by
reallocating, which needs the old and new buffers alive simultaneously, so the
peak requirement is larger still.

```
abort <- __cxa_allocate_exception <- operator new
     <- std::string::_M_mutate <- _M_append <- add_memory_image
```

Reservoir sampling (Algorithm R, k=1) keeps a single candidate and replaces it
with probability 1/n. O(1) regardless of window size, and it selects uniformly —
exactly what indexing into the full list did. `memory_image_ids` and
`select_memory_image()` are no longer needed.

The second failure is only reachable once the response can be parsed at all, so
it surfaced immediately after the first was fixed.

## How this was found

Both were latent until recently. Immich >=3.0.3 rejects the datetime form of the
`for` parameter, so `/api/memories` returns 400 with a small error body and the
frame silently falls back to random photos — nothing large is ever parsed. The
400 was acting as an accidental guard.

Fixing the date format (#140) is what allowed a full-size response through. Each
failure then reproduced within seconds of selecting the Memories source, and
ESP-IDF rolled the OTA back both times.

**#140 is worth taking on its own** — it is a one-line fix that everyone on
Immich >=3.0.3 needs. This PR is the narrower case: it only matters once a
library is large enough for the response to exceed what the heap can allocate in
one block. Smaller libraries would see no difference either way, which is likely
why this has gone unreported.

## Verification

- Both aborts reproduced on hardware with symbolized backtraces, then confirmed
  gone.
- The device has since run continuously on the Memories source: ~2,058 memory
  photos fetched over nine hours, no aborts, no reboots.
- Largest free internal-DRAM block held **flat at 30,208 bytes across 2,530
  samples** over that period — previously 21,504-28,160 and dipping below the
  size of the allocations above. No fragmentation drift.
- `npm run test:helpers` passes; the `ImmichRequestState` test is updated for the
  new selection behaviour. The stubbed `esp_random()` returns 0, so the assertion
  stays deterministic.
- `builds/guition-esp32-p4-jc8012p4a1.factory.yaml` compiles clean.

## Note on #140

This branch is cut from `main` and stands alone, but it touches lines adjacent to
#140, so the two conflict textually. The resolution is mechanical — take the
date-only `return` from #140 and the `capture_response` removal from here. Happy
to rebase onto #140 or restack in whatever order suits you.

## Unrelated, but noticed

`main` currently fails `npm run check:product` before any of these changes — the
`actions/setup-node@v7` bump in #135 did not update `product/contract`, and the
ESPHome `2026.6.4` version strings are missing from `README.md`,
`docs/install.md`, and `docs/manual-setup.md`. Not touched here.
