### PR TITLE
fix: slot flush leaves in-flight state behind, stalling and sometimes deadlocking the slideshow

### DIFF
--- a/common/addon/immich_filter.yaml
+++ b/common/addon/immich_filter.yaml
@@ -350,6 +350,22 @@ script:
             - script.execute: immich_retry_config_ready
             - script.stop: flush_slots_and_refetch
       - lambda: |-
+          // A flush discards every slot, so it has to discard the work that was
+          // filling them too. Clearing `ready` while leaving fetch_in_flight set
+          // orphans the flag: request_prefetch() and the slideshow interval both
+          // gate on it, so the refill this flush is about to request either
+          // defers or never runs at all. Abort the downloads and clear the
+          // tracking first.
+          id(immich_img_0).abort_download();
+          id(immich_img_1).abort_download();
+          id(immich_img_2).abort_download();
+          id(immich_portrait_left).abort_download();
+          id(immich_portrait_right).abort_download();
+          id(immich_portrait_preload_left).abort_download();
+          id(immich_portrait_preload_right).abort_download();
+          clear_slot_fetch_in_flight(0, id(espframe_core).slideshow().state().slot_flags);
+          clear_slot_fetch_in_flight(1, id(espframe_core).slideshow().state().slot_flags);
+          clear_slot_fetch_in_flight(2, id(espframe_core).slideshow().state().slot_flags);
           id(espframe_core).slideshow().state().slot0.ready = false;
           id(espframe_core).slideshow().state().slot1.ready = false;
           id(espframe_core).slideshow().state().slot2.ready = false;

--- a/common/addon/immich_filter.yaml
+++ b/common/addon/immich_filter.yaml
@@ -372,10 +372,20 @@ script:
           id(espframe_core).slideshow().state().portrait_preload_slot = -1;
           id(espframe_core).slideshow().state().portrait_preload_left_ready = false;
           id(espframe_core).slideshow().state().portrait_preload_right_ready = false;
-          if (id(espframe_core).slideshow().state().preload_noncritical_in_flight) {
-            id(espframe_core).slideshow().state().preload_noncritical_in_flight = false;
-            if (id(espframe_core).slideshow().state().noncritical_remote_updates_in_flight > 0) id(espframe_core).slideshow().state().noncritical_remote_updates_in_flight--;
-          }
+          // Same reasoning for the non-critical update tracking: the flush
+          // cancels every outstanding update, so the per-slot flags and the
+          // counter both have to go, not just the preload flag. Clearing them
+          // together is what makes zeroing the counter safe — clear_noncritical()
+          // only decrements when the slot's flag is still set, so a completion
+          // arriving after the flush finds the flag already false and leaves the
+          // counter alone. Left partially reset, a stuck non-zero count makes
+          // both request_prefetch() and prepare_deferred_slot_update() refuse to
+          // do any further work.
+          id(espframe_core).slideshow().state().slot_flags.noncritical_update[0] = false;
+          id(espframe_core).slideshow().state().slot_flags.noncritical_update[1] = false;
+          id(espframe_core).slideshow().state().slot_flags.noncritical_update[2] = false;
+          id(espframe_core).slideshow().state().preload_noncritical_in_flight = false;
+          id(espframe_core).slideshow().state().noncritical_remote_updates_in_flight = 0;
           id(espframe_core).slideshow().state().active_slot_displayed = false;
           id(espframe_core).slideshow().state().target_slot = id(espframe_core).slideshow().state().active_slot;
       - script.execute: immich_fetch_into_slot


### PR DESCRIPTION
# fix: slot flush leaves in-flight state behind, stalling and sometimes deadlocking the slideshow

## Summary

`flush_slots_and_refetch` discards all three slots and then asks for a refill,
but it only resets each slot's `ready` flag. The pipeline's in-flight tracking is
left behind, and both refill paths gate on exactly that tracking — so the flush
breaks the refill it exists to trigger.

The visible result is a frame that stops advancing while looking completely
healthy over the network: ping responds, the web server returns 200 to every
button press, WiFi is fine, uptime keeps climbing. Only a reboot recovers it.

## Related

I have two other PRs open. All three are independent bugs in different areas:

- **#140** — one line, the `/api/memories` date format for Immich >=3.0.3.
  Trivially reviewable and worth taking on its own.
- **#142** — DRAM allocation aborts in the memories parse path. Only bites once a
  library is large enough.
- This one — slideshow pipeline state after a flush. It touches a different file
  (`immich_filter.yaml`) than either of the others and merges cleanly with both.

Only #140 and #142 overlap: they touch adjacent lines in `immich_api.yaml`, so
whichever lands first leaves the other a one-hunk resolution. Nothing here
depends on either of them, and none of the three need to be taken as a set. Happy
to rebase any of them whenever it is useful.

## What the flush leaves set

- the in-flight image downloads themselves (all seven `remote_image` components)
- `slot_flags.fetch_in_flight[0..2]`
- `slot_flags.noncritical_update[0..2]`, `preload_noncritical_in_flight`, and
  most of `noncritical_remote_updates_in_flight` — the existing code clears the
  preload flag and decrements the counter by one, which is not the same as
  cancelling everything the flush just threw away

## Two failure modes

**1. The refill defers into a gate the flush itself just closed (frequent,
self-recovering).** The flush sets `active_slot_displayed = false` and calls
`immich_fetch_into_slot`. Seeing a fetch already in flight, that defers into
`delayed_prefetch_chain → immich_prefetch_chain → request_prefetch()`, which
returns immediately on:

```cpp
if (!active_slot_displayed) return false;   // slideshow_component.h:542
```

So the flush's own refill never runs. The slideshow sits frozen until the
interval's timed advance rescues it one interval later.

**2. Permanent deadlock (intermittent).** If the orphaned `fetch_in_flight`
belongs to a **non-active** slot, `any_slot_fetch_in_flight()` stays true
forever. `advance_forward`'s 15-second stuck-slot self-heal only ever clears the
*active* slot, so nothing can reach it, and the interval rescue is blocked too.
The slideshow never advances again. This is the one that needs a reboot.

A stuck `noncritical_remote_updates_in_flight` wedges things the same way —
`request_prefetch()` and `prepare_deferred_slot_update()` both refuse to proceed
while it is non-zero.

## The fix

Make a flush an actual reset. Abort the in-flight downloads, clear
`fetch_in_flight` for all three slots, and fully reset the non-critical update
tracking. `immich_fetch_into_slot` then proceeds immediately rather than
deferring, so it never reaches the `active_slot_displayed` gate, and no stale
flag survives to wedge the interval recovery.

On zeroing the counter: clearing the per-slot flags alongside it is what makes
that safe. `clear_noncritical()` only decrements when the slot's flag is still
set, so a completion arriving after the flush finds the flag already false and
leaves the counter alone. There is no path that can drive it negative.

## Verification

Measured on an ESP32-P4 Guition `jc8012p4a1`. Driving `apply_photo_source` every
12 seconds, 60 presses per run:

| build | post-flush stalls | max render gap | hang within 60 presses | stuck flags |
|---|---:|---:|---|---|
| unpatched | 29 | ~76s | yes, wedged at #59 | `fetch_in_flight` + `nc` |
| patched | 4 | ~29s | none | none — remaining are real, transient |

The stronger result is the deadlock path. A 500-cycle soak reproducing the
pattern that had previously produced **four permanent hangs in one night**, each
needing a reboot, ran to completion with **zero**. Both arms ran the identical
cycle pattern on the same hardware and the same firmware base, differing only in
this patch. The fix has been on the device since 2026-07-23 with no recurrence.

Under ordinary use the deadlock showed up every one to two days, which is what
made it hard to pin down. Hammering `apply_photo_source` compresses the same race
into minutes.

Note that the pipeline is only observably wedged rather than crashed — there is
no panic and no backtrace, because nothing faults. The code simply stops being
allowed to proceed. Diagnosing it needed a state-dump heartbeat; that
instrumentation is deliberately not part of this PR.

`builds/guition-esp32-p4-jc8012p4a1.factory.yaml` compiles clean and
`npm run test:helpers` passes.

## Unrelated, but noticed

`main` currently fails `npm run check:product` before any of these changes — the
`actions/setup-node@v7` bump in #135 did not update `product/contract`, and the
ESPHome `2026.6.4` version strings are missing from `README.md`,
`docs/install.md`, and `docs/manual-setup.md`. Not touched here.
