### PR TITLE
Document Immich permission for filtered photo sources

### DIFF
--- a/docs/api-key.md
+++ b/docs/api-key.md
@@ -12,6 +12,7 @@ Espframe needs a read-only API key; it never modifies or uploads. **Account Sett
 | Permission | Why |
 |---|---|
 | `asset.read` | Search for random photos and read metadata (date, location, EXIF) |
+| `asset.statistics` | Count matching photos for album, person, and tag sources |
 | `asset.view` | Download photo thumbnails for display |
 | `person.read` | Show people's names on the photo overlay |
 | `album.read` | Album names a photo belongs to |

--- a/product/contract/project.json
+++ b/product/contract/project.json
@@ -26,6 +26,10 @@
       "purpose": "Search for random photos and read metadata (date, location, EXIF)"
     },
     {
+      "name": "asset.statistics",
+      "purpose": "Count matching photos for album, person, and tag sources"
+    },
+    {
       "name": "asset.view",
       "purpose": "Download photo thumbnails for display"
     },

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -27,6 +27,10 @@
         "purpose": "Search for random photos and read metadata (date, location, EXIF)"
       },
       {
+        "name": "asset.statistics",
+        "purpose": "Count matching photos for album, person, and tag sources"
+      },
+      {
         "name": "asset.view",
         "purpose": "Download photo thumbnails for display"
       },

--- a/scripts/product_contract/project_feature_metadata_shape.py
+++ b/scripts/product_contract/project_feature_metadata_shape.py
@@ -263,8 +263,8 @@ def check_project_api_key_feature_metadata_shape(product: dict, errors: list[str
                 errors.append("project.immich_api_key_permissions entry is missing name")
             elif name in seen_permissions:
                 errors.append(f"Duplicate Immich API key permission: {name}")
-            elif not re.match(r"^[a-z]+\.(read|view)$", name):
-                errors.append(f"Immich API key permission should be read/view-only: {name}")
+            elif not re.match(r"^[a-z]+\.(read|view|statistics)$", name):
+                errors.append(f"Immich API key permission should be read-only: {name}")
             seen_permissions.add(name)
             if not purpose:
                 errors.append(f"Immich API key permission {name or '<missing>'} is missing purpose")


### PR DESCRIPTION
## What changed

- add `asset.statistics` to the recommended Immich API key permissions
- explain that Espframe uses it to count matching album, person, and tag photos
- keep the generated product metadata and read-only permission validation in sync

## Why

Album, Person, and Tag photo sources call Immich's `/api/search/statistics` endpoint. Immich requires `asset.statistics` for that endpoint, so a key created from the previous documentation could receive HTTP 403 errors.

## Validation

- `npm run check:fast`
- `npm run docs:build`

Closes #138