### PR TITLE
Fix shared album filtering

### DIFF
--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -324,6 +324,52 @@ script:
                 then:
                   - script.execute: immich_retry_config_ready
             - script.stop: immich_fetch_metadata_into_slot
+      - lambda: |-
+          std::string source = id(photo_source_select).current_option();
+          bool resume_album_fallback = source == "Album" &&
+            id(immich_request_state).should_resume_album_metadata_fallback(millis());
+          id(immich_request_state).clear_album_metadata_fallback_request();
+          if (source == "Album" && !resume_album_fallback) {
+            id(immich_request_state).metadata_album_id = pick_album_id_for_metadata_search(
+              id(immich_album_ids).state,
+              id(immich_album_order).current_option(),
+              id(immich_request_state).album_order_index);
+          } else if (source != "Album") {
+            id(immich_request_state).metadata_album_id = "";
+          }
+          id(immich_request_state).metadata_person_id = source == "Person"
+            ? pick_one_person_id_for_random_search(id(immich_person_ids).state)
+            : "";
+          id(immich_request_state).metadata_tag_ids = source == "Tag"
+            ? id(immich_tag_ids).state
+            : "";
+          if (resume_album_fallback) {
+            id(immich_request_state).begin_album_metadata_fallback(
+              id(immich_request_state).metadata_album_id);
+            ESP_LOGD("immich", "Album statistics fallback retry: metadata page %d",
+                     id(immich_request_state).metadata_page);
+            id(immich_fetch_metadata_page).execute();
+          }
+      - if:
+          condition:
+            lambda: |-
+              return id(immich_request_state).metadata_album_fallback;
+          then:
+            - script.stop: immich_fetch_metadata_into_slot
+      - if:
+          condition:
+            lambda: |-
+              return id(photo_source_select).current_option() == "Album" &&
+                     id(immich_request_state).album_metadata_fallback_active(
+                       id(immich_request_state).metadata_album_id, millis());
+          then:
+            - lambda: |-
+                id(immich_request_state).begin_album_metadata_fallback(
+                  id(immich_request_state).metadata_album_id);
+                ESP_LOGD("immich", "Album statistics fallback: metadata page %d",
+                         id(immich_request_state).metadata_page);
+            - script.execute: immich_fetch_metadata_page
+            - script.stop: immich_fetch_metadata_into_slot
       - http_request.post:
           id: http_req
           url: !lambda 'return id(immich_url).state + "/api/search/statistics";'
@@ -335,14 +381,6 @@ script:
             x-api-key: !lambda 'return id(immich_api_key_text).state.c_str();'
           body: !lambda |-
             std::string source = id(photo_source_select).current_option();
-            id(immich_request_state).metadata_album_id = source == "Album"
-              ? pick_album_id_for_metadata_search(
-                  id(immich_album_ids).state,
-                  id(immich_album_order).current_option(),
-                  id(immich_request_state).album_order_index)
-              : "";
-            id(immich_request_state).metadata_person_id = source == "Person" ? pick_one_person_id_for_random_search(id(immich_person_ids).state) : "";
-            id(immich_request_state).metadata_tag_ids = source == "Tag" ? id(immich_tag_ids).state : "";
             auto now = id(sntp_time).now();
             ImmichDateRange range = resolve_immich_date_filter(
               id(immich_date_filter_enabled).state,
@@ -371,6 +409,12 @@ script:
                   id(immich_request_state).clear_http_status();
                   uint32_t total = parse_immich_statistics_total(body);
                   if (total == 0) {
+                    if (id(photo_source_select).current_option() == "Album") {
+                      id(immich_request_state).begin_album_statistics_probe();
+                      ESP_LOGI("immich", "Album statistics returned zero; checking metadata");
+                      id(immich_fetch_metadata_page).execute();
+                      return;
+                    }
                     clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
                     ESP_LOGW("immich", "Statistics source has no matching images");
                     id(immich_request_state).reset_retries_and_pause(millis());
@@ -449,9 +493,33 @@ script:
               - lambda: |-
                   if (response->status_code != 200) {
                     ESP_LOGW("immich", "Metadata page HTTP %d", response->status_code);
+                    if (id(immich_request_state).metadata_album_fallback) {
+                      id(immich_request_state).retry_album_metadata_fallback();
+                    }
                     clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
                     id(immich_request_state).record_http_failure(response->status_code, millis());
                     return;
+                  }
+                  bool album_statistics_probe = id(immich_request_state).metadata_album_statistics_probe;
+                  bool album_metadata_fallback = id(immich_request_state).metadata_album_fallback;
+                  ImmichMetadataPageInfo page_info = parse_immich_metadata_page_info(body);
+                  bool statistics_mismatch = false;
+                  if (album_metadata_fallback) {
+                    statistics_mismatch = id(immich_request_state).finish_album_metadata_page(
+                      page_info.item_count > 0, page_info.next_page, millis());
+                    if (statistics_mismatch) {
+                      ESP_LOGI("immich", "Album statistics mismatch; using metadata paging for 30 minutes");
+                    }
+                    if (page_info.item_count == 0) {
+                      clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
+                      if (album_statistics_probe) {
+                        ESP_LOGW("immich", "Album metadata has no matching images");
+                      } else {
+                        ESP_LOGW("immich", "Album metadata fallback page is empty; resetting to page 1");
+                      }
+                      id(immich_request_state).reset_retries_and_pause(millis());
+                      return;
+                    }
                   }
                   std::string orientation = id(photo_orientation_filter).current_option();
                   std::string img_url = parse_immich_metadata_asset_and_fill_slot(
@@ -460,6 +528,9 @@ script:
                   if (img_url.empty()) {
                     clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
                     if (orientation != "Any" && id(immich_request_state).retry_available(MAX_ERROR_RETRIES)) {
+                      if (album_metadata_fallback) {
+                        id(immich_request_state).retry_album_metadata_fallback();
+                      }
                       id(immich_request_state).register_request_error();
                       ESP_LOGW("immich", "No %s image in metadata page; retrying", orientation.c_str());
                       id(immich_fetch_retry).execute();
@@ -488,6 +559,9 @@ script:
           on_error:
             then:
               - lambda: |-
+                  if (id(immich_request_state).metadata_album_fallback) {
+                    id(immich_request_state).retry_album_metadata_fallback();
+                  }
                   id(immich_request_state).register_request_error();
                   ESP_LOGW("immich", "Metadata page request error for slot %d (attempt %d)", id(espframe_core).slideshow().state().target_slot, id(immich_request_state).api_retries);
                   clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);

--- a/common/addon/immich_filter.yaml
+++ b/common/addon/immich_filter.yaml
@@ -350,6 +350,9 @@ script:
             - script.execute: immich_retry_config_ready
             - script.stop: flush_slots_and_refetch
       - lambda: |-
+          // Album metadata fallback pages depend on the active source and
+          // filters, so discard their RAM-only cursors whenever this applies.
+          id(immich_request_state).reset_album_metadata_fallbacks();
           // A flush discards every slot, so it has to discard the work that was
           // filling them too. Clearing `ready` while leaving fetch_in_flight set
           // orphans the flag: request_prefetch() and the slideshow interval both

--- a/components/espframe/immich_helpers.h
+++ b/components/espframe/immich_helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "date_utils.h"
 #include "esp_random.h"
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -10,6 +11,14 @@
 static constexpr uint16_t ZOOM_IDENTITY = 256;
 static constexpr uint16_t IMMICH_ALBUM_PAGE_SIZE = 16;
 static constexpr uint16_t IMMICH_METADATA_PAGE_SIZE = 5;
+static constexpr uint32_t IMMICH_ALBUM_METADATA_FALLBACK_MS = 30 * 60 * 1000;
+static constexpr size_t IMMICH_MAX_ALBUM_METADATA_FALLBACKS = 6;
+
+struct ImmichAlbumMetadataFallback {
+  std::string album_id;
+  uint32_t next_page = 1;
+  uint32_t active_until_ms = 0;
+};
 
 // Owns the complete state of the Immich request pipeline. Keeping these values
 // together makes reset, retry, and cooldown transitions atomic instead of
@@ -32,7 +41,11 @@ struct ImmichRequestState {
   std::string metadata_tag_ids;
   int metadata_page = 1;
   int metadata_page_size = 1;
-  uint32_t metadata_bypass_until_ms = 0;
+  bool metadata_album_fallback = false;
+  bool metadata_album_statistics_probe = false;
+  bool metadata_album_fallback_retry = false;
+  std::array<ImmichAlbumMetadataFallback, IMMICH_MAX_ALBUM_METADATA_FALLBACKS>
+      album_metadata_fallbacks{};
   int album_order_index = 0;
 
   void reset() { *this = ImmichRequestState{}; }
@@ -42,6 +55,71 @@ struct ImmichRequestState {
     this->memory_asset_id.clear();
     this->memory_window_offset = -2;
     this->memory_image_count = 0;
+  }
+
+  void reset_album_metadata_fallbacks() {
+    for (auto &fallback : this->album_metadata_fallbacks) {
+      fallback = {};
+    }
+    this->metadata_album_fallback = false;
+    this->metadata_album_statistics_probe = false;
+    this->metadata_album_fallback_retry = false;
+  }
+
+  void clear_album_metadata_fallback_request() {
+    this->metadata_album_fallback = false;
+    this->metadata_album_statistics_probe = false;
+    this->metadata_album_fallback_retry = false;
+  }
+
+  bool should_resume_album_metadata_fallback(uint32_t now_ms) const {
+    return this->metadata_album_fallback_retry &&
+           this->album_metadata_fallback_active(this->metadata_album_id, now_ms);
+  }
+
+  void retry_album_metadata_fallback() {
+    this->metadata_album_fallback_retry = true;
+    this->metadata_album_statistics_probe = false;
+  }
+
+  bool album_metadata_fallback_active(const std::string &album_id, uint32_t now_ms) const {
+    const auto *fallback = this->find_album_metadata_fallback_(album_id);
+    return fallback != nullptr && fallback->active_until_ms != 0 && now_ms < fallback->active_until_ms;
+  }
+
+  void begin_album_metadata_fallback(const std::string &album_id) {
+    this->metadata_album_fallback = true;
+    this->metadata_album_statistics_probe = false;
+    this->metadata_album_fallback_retry = false;
+    const auto *fallback = this->find_album_metadata_fallback_(album_id);
+    this->metadata_page = fallback != nullptr && fallback->next_page > 0 ? fallback->next_page : 1;
+    this->metadata_page_size = IMMICH_METADATA_PAGE_SIZE;
+  }
+
+  void begin_album_statistics_probe() {
+    this->metadata_album_fallback = true;
+    this->metadata_album_statistics_probe = true;
+    this->metadata_album_fallback_retry = false;
+    this->metadata_page = 1;
+    this->metadata_page_size = IMMICH_METADATA_PAGE_SIZE;
+  }
+
+  // Store the next metadata page for this album. A non-empty probe response
+  // confirms Immich's statistics endpoint cannot count this readable album.
+  bool finish_album_metadata_page(bool has_items, uint32_t next_page, uint32_t now_ms) {
+    if (!this->metadata_album_fallback || this->metadata_album_id.empty()) return false;
+
+    bool statistics_mismatch = this->metadata_album_statistics_probe && has_items;
+    auto *fallback = this->find_or_create_album_metadata_fallback_(this->metadata_album_id);
+    if (fallback != nullptr) {
+      fallback->next_page = has_items && next_page > 0 ? next_page : 1;
+      if (statistics_mismatch) {
+        fallback->active_until_ms = now_ms + IMMICH_ALBUM_METADATA_FALLBACK_MS;
+      }
+    }
+    this->metadata_album_fallback = false;
+    this->metadata_album_statistics_probe = false;
+    return statistics_mismatch;
   }
 
   bool advance_memory_window() {
@@ -136,6 +214,28 @@ struct ImmichRequestState {
   }
 
  private:
+  const ImmichAlbumMetadataFallback *find_album_metadata_fallback_(const std::string &album_id) const {
+    if (album_id.empty()) return nullptr;
+    for (const auto &fallback : this->album_metadata_fallbacks) {
+      if (fallback.album_id == album_id) return &fallback;
+    }
+    return nullptr;
+  }
+
+  ImmichAlbumMetadataFallback *find_or_create_album_metadata_fallback_(const std::string &album_id) {
+    if (album_id.empty()) return nullptr;
+    for (auto &fallback : this->album_metadata_fallbacks) {
+      if (fallback.album_id == album_id) return &fallback;
+    }
+    for (auto &fallback : this->album_metadata_fallbacks) {
+      if (fallback.album_id.empty()) {
+        fallback.album_id = album_id;
+        return &fallback;
+      }
+    }
+    return nullptr;
+  }
+
   void record_failure_(uint32_t now_ms) {
     this->consecutive_failures++;
     if (this->failure_window_started_ms == 0) this->failure_window_started_ms = now_ms;
@@ -541,6 +641,17 @@ inline std::string pick_immich_timeline_asset_id_from_candidates(
   return candidates[esp_random() % candidates.size()];
 }
 
+inline uint32_t parse_immich_metadata_next_page_value(const std::string &value) {
+  if (value.empty()) return 0;
+  char *end = nullptr;
+  unsigned long page = strtoul(value.c_str(), &end, 10);
+  if (end == value.c_str() || *end != '\0' || page == 0 ||
+      page > static_cast<unsigned long>(UINT32_MAX)) {
+    return 0;
+  }
+  return static_cast<uint32_t>(page);
+}
+
 // ============================================================================
 // Immich asset parser — parse JSON asset and fill meta
 // ============================================================================
@@ -697,6 +808,35 @@ inline uint32_t parse_immich_statistics_total(const std::string &body) {
   if (root["total"].is<int>()) total = root["total"].as<int>();
   if (total <= 0 && root["images"].is<int>()) total = root["images"].as<int>();
   return total > 0 ? static_cast<uint32_t>(total) : 0;
+}
+
+struct ImmichMetadataPageInfo {
+  size_t item_count = 0;
+  uint32_t next_page = 0;
+};
+
+inline ImmichMetadataPageInfo parse_immich_metadata_page_info(const std::string &body) {
+  auto doc = esphome::json::parse_json(body);
+  if (doc.isNull() || !doc.is<JsonObject>()) return {};
+
+  JsonObject assets = doc.as<JsonObject>()["assets"].as<JsonObject>();
+  if (assets.isNull()) return {};
+
+  JsonArray items = assets["items"].as<JsonArray>();
+  if (items.isNull() && assets["assets"].is<JsonArray>()) {
+    items = assets["assets"].as<JsonArray>();
+  }
+
+  ImmichMetadataPageInfo info;
+  if (!items.isNull()) info.item_count = items.size();
+  if (assets["nextPage"].is<int>()) {
+    info.next_page = parse_immich_metadata_next_page_value(
+        std::to_string(assets["nextPage"].as<int>()));
+  } else if (assets["nextPage"].is<const char *>()) {
+    info.next_page = parse_immich_metadata_next_page_value(
+        assets["nextPage"].as<const char *>());
+  }
+  return info;
 }
 
 inline std::string parse_immich_metadata_asset(const std::string &body,

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -251,6 +251,12 @@ static void test_immich_body_helpers() {
   assert(build_immich_statistics_search_body("Tag", "", "", "t1,t2")
              .find("\"tagIds\":[\"t1\",\"t2\"]") != std::string::npos);
 
+  assert(parse_immich_metadata_next_page_value("7") == 7);
+  assert(parse_immich_metadata_next_page_value("3") == 3);
+  assert(parse_immich_metadata_next_page_value("") == 0);
+  assert(parse_immich_metadata_next_page_value("null") == 0);
+  assert(parse_immich_metadata_next_page_value("1x") == 0);
+
   std::vector<ImmichTimelineBucketInfo> large_album_buckets = {
       {"2026-05-01", 848},
       {"2026-04-01", 12},
@@ -297,6 +303,46 @@ static void test_immich_request_state() {
   assert(state.memory_asset_id == "asset-b");
   assert(state.advance_memory_window());
   assert(state.memory_window_offset == -1);
+
+  state.metadata_album_id = "album-a";
+  state.begin_album_statistics_probe();
+  assert(state.metadata_album_fallback);
+  assert(state.metadata_album_statistics_probe);
+  assert(state.metadata_page == 1);
+  assert(state.metadata_page_size == IMMICH_METADATA_PAGE_SIZE);
+  assert(state.finish_album_metadata_page(true, 4, 1000));
+  assert(state.album_metadata_fallback_active("album-a", 1001));
+  state.begin_album_metadata_fallback("album-a");
+  assert(state.metadata_page == 4);
+  assert(!state.metadata_album_statistics_probe);
+  state.retry_album_metadata_fallback();
+  assert(state.should_resume_album_metadata_fallback(1002));
+  state.clear_album_metadata_fallback_request();
+  assert(!state.should_resume_album_metadata_fallback(1002));
+
+  state.metadata_album_id = "album-b";
+  state.begin_album_statistics_probe();
+  assert(state.finish_album_metadata_page(true, 2, 2000));
+  state.begin_album_metadata_fallback("album-b");
+  assert(state.metadata_page == 2);
+  state.begin_album_metadata_fallback("album-a");
+  assert(state.metadata_page == 4);
+
+  state.metadata_album_id = "album-a";
+  state.begin_album_metadata_fallback("album-a");
+  assert(!state.finish_album_metadata_page(true, 0, 3000));
+  state.begin_album_metadata_fallback("album-a");
+  assert(state.metadata_page == 1);
+  assert(!state.album_metadata_fallback_active("album-a", 1000 + IMMICH_ALBUM_METADATA_FALLBACK_MS));
+
+  state.metadata_album_id = "empty-album";
+  state.begin_album_statistics_probe();
+  assert(!state.finish_album_metadata_page(false, 0, 4000));
+  assert(!state.album_metadata_fallback_active("empty-album", 4001));
+
+  state.reset_album_metadata_fallbacks();
+  assert(!state.album_metadata_fallback_active("album-a", 3001));
+  assert(!state.album_metadata_fallback_active("album-b", 3001));
 
   assert(state.register_request_error() == 1);
   assert(state.prepare_retry_delay() == 2000);


### PR DESCRIPTION
Fixes #133.

## What changed
- Probe Immich metadata when album statistics incorrectly reports zero results.
- Cache per-album metadata cursors for 30 minutes, including independent paging and orientation retries.
- Keep genuine empty albums and HTTP/permission failures distinct in logs.

## Validation
- `npm run test:helpers`
- `npm run check:fast`
- Generated firmware `main.cpp` compiled for the Guition 10-inch target.