### PR TITLE
Fix shared album photo pagination

### DIFF
--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -283,8 +283,9 @@ script:
               - script.execute: immich_fetch_into_slot
 
   # ---------------------------------------------------------------------------
-  # Fetch a random asset from Album, Person, and Tag sources using statistics
-  # plus paged metadata search.
+  # Fetch a random asset from Album, Person, and Tag sources using paged metadata search.
+  # Album counts come from the album endpoint so shared-album
+  # contributors are included; Person and Tag counts use search statistics.
   #
   # Immich metadata page count can mirror the current page size in some server
   # versions. Statistics returns the real matching total, then metadata fetches
@@ -324,6 +325,96 @@ script:
                 then:
                   - script.execute: immich_retry_config_ready
             - script.stop: immich_fetch_metadata_into_slot
+      - lambda: |-
+          std::string source = id(photo_source_select).current_option();
+          id(immich_request_state).metadata_album_id = source == "Album"
+            ? pick_album_id_for_metadata_search(
+                id(immich_album_ids).state,
+                id(immich_album_order).current_option(),
+                id(immich_request_state).album_order_index)
+            : "";
+          id(immich_request_state).metadata_person_id = source == "Person" ? pick_one_person_id_for_random_search(id(immich_person_ids).state) : "";
+          id(immich_request_state).metadata_tag_ids = source == "Tag" ? id(immich_tag_ids).state : "";
+          id(immich_request_state).metadata_page = 1;
+          id(immich_request_state).metadata_max_page = 1;
+          id(immich_request_state).metadata_empty_page_probes = 0;
+          id(immich_request_state).metadata_page_bound_is_upper = false;
+          id(immich_request_state).metadata_page1_fallback_attempted = false;
+          id(immich_request_state).metadata_page_size =
+            id(photo_orientation_filter).current_option() == "Any" ? 1 : IMMICH_METADATA_PAGE_SIZE;
+      - if:
+          condition:
+            lambda: 'return id(photo_source_select).current_option() == "Album";'
+          then:
+            - script.execute: immich_fetch_album_count
+            - script.stop: immich_fetch_metadata_into_slot
+      - script.execute: immich_fetch_statistics_count
+
+  - id: immich_fetch_album_count
+    mode: single
+    then:
+      - http_request.get:
+          id: http_req
+          # Immich v1 returned every asset unless this query was supplied;
+          # current versions ignore it because album info no longer embeds assets.
+          url: !lambda 'return id(immich_url).state + "/api/albums/" + id(immich_request_state).metadata_album_id + "?withoutAssets=true";'
+          capture_response: true
+          max_response_buffer_size: 24kB
+          request_headers:
+            Accept: application/json
+            x-api-key: !lambda 'return id(immich_api_key_text).state.c_str();'
+          on_response:
+            then:
+              - lambda: |-
+                  if (response->status_code != 200) {
+                    ESP_LOGW("immich", "Album count HTTP %d", response->status_code);
+                    clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
+                    id(immich_request_state).record_http_failure(response->status_code, millis());
+                    return;
+                  }
+                  uint32_t total = 0;
+                  if (!parse_immich_album_asset_count(body, &total)) {
+                    clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
+                    ESP_LOGW("immich", "Album count response did not contain assetCount");
+                    id(espframe_core).slideshow().state().diagnostic_reason = "album count response invalid";
+                    id(log_immich_diag).execute();
+                    id(immich_register_fetch_failure).execute();
+                    return;
+                  }
+                  id(immich_fetch_started) = true;
+                  id(immich_request_state).clear_http_status();
+                  if (total == 0) {
+                    clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
+                    ESP_LOGW("immich", "Album source has no assets");
+                    id(immich_request_state).reset_retries_and_pause(millis());
+                    return;
+                  }
+                  initialize_immich_metadata_page_range(
+                    id(immich_request_state), total, id(immich_request_state).metadata_page_size, true);
+                  ESP_LOGD("immich", "Album source selected: page %d size %d of %u assets",
+                           id(immich_request_state).metadata_page, id(immich_request_state).metadata_page_size, (unsigned) total);
+                  id(immich_fetch_metadata_page).execute();
+          on_error:
+            then:
+              - lambda: |-
+                  id(immich_request_state).register_request_error();
+                  ESP_LOGW("immich", "Album count request error for slot %d (attempt %d)", id(espframe_core).slideshow().state().target_slot, id(immich_request_state).api_retries);
+                  clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
+                  id(espframe_core).slideshow().state().diagnostic_reason = "album count request error";
+                  id(log_immich_diag).execute();
+              - if:
+                  condition:
+                    lambda: 'return id(immich_request_state).retry_available(MAX_ERROR_RETRIES);'
+                  then:
+                    - script.execute: immich_fetch_retry
+                  else:
+                    - lambda: |-
+                        id(immich_request_state).reset_retries_and_pause(millis());
+                        ESP_LOGW("immich", "Album count retries exhausted; pausing Immich fetches for 30s");
+
+  - id: immich_fetch_statistics_count
+    mode: single
+    then:
       - http_request.post:
           id: http_req
           url: !lambda 'return id(immich_url).state + "/api/search/statistics";'
@@ -334,15 +425,6 @@ script:
             Accept: application/json
             x-api-key: !lambda 'return id(immich_api_key_text).state.c_str();'
           body: !lambda |-
-            std::string source = id(photo_source_select).current_option();
-            id(immich_request_state).metadata_album_id = source == "Album"
-              ? pick_album_id_for_metadata_search(
-                  id(immich_album_ids).state,
-                  id(immich_album_order).current_option(),
-                  id(immich_request_state).album_order_index)
-              : "";
-            id(immich_request_state).metadata_person_id = source == "Person" ? pick_one_person_id_for_random_search(id(immich_person_ids).state) : "";
-            id(immich_request_state).metadata_tag_ids = source == "Tag" ? id(immich_tag_ids).state : "";
             auto now = id(sntp_time).now();
             ImmichDateRange range = resolve_immich_date_filter(
               id(immich_date_filter_enabled).state,
@@ -356,7 +438,7 @@ script:
             }
             std::string extra = build_immich_date_filter_extra(range);
             return build_immich_statistics_search_body(
-              source, id(immich_request_state).metadata_album_id,
+              id(photo_source_select).current_option(), id(immich_request_state).metadata_album_id,
               id(immich_request_state).metadata_person_id, id(immich_request_state).metadata_tag_ids, extra);
           on_response:
             then:
@@ -376,10 +458,8 @@ script:
                     id(immich_request_state).reset_retries_and_pause(millis());
                     return;
                   }
-                  std::string orientation = id(photo_orientation_filter).current_option();
-                  id(immich_request_state).metadata_page_size = orientation == "Any" ? 1 : IMMICH_METADATA_PAGE_SIZE;
-                  id(immich_request_state).metadata_page = immich_metadata_page_for_total(
-                    total, id(immich_request_state).metadata_page_size);
+                  initialize_immich_metadata_page_range(
+                    id(immich_request_state), total, id(immich_request_state).metadata_page_size, false);
                   ESP_LOGD("immich", "Metadata source selected: page %d size %d of %u matching images",
                            id(immich_request_state).metadata_page, id(immich_request_state).metadata_page_size, (unsigned) total);
                   id(immich_fetch_metadata_page).execute();
@@ -400,6 +480,15 @@ script:
                     - lambda: |-
                         id(immich_request_state).reset_retries_and_pause(millis());
                         ESP_LOGW("immich", "Metadata retries exhausted; pausing Immich fetches for 30s");
+
+  - id: immich_fetch_metadata_page_probe
+    mode: restart
+    then:
+      - delay: 250ms
+      - lambda: |-
+          mark_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot,
+                                    id(espframe_core).slideshow().state().slot_flags, millis());
+      - script.execute: immich_fetch_metadata_page
 
   - id: immich_fetch_metadata_page
     mode: single
@@ -454,12 +543,32 @@ script:
                     return;
                   }
                   std::string orientation = id(photo_orientation_filter).current_option();
+                  size_t metadata_item_count = 0;
+                  bool metadata_response_valid = parse_immich_metadata_item_count(body, &metadata_item_count);
                   std::string img_url = parse_immich_metadata_asset_and_fill_slot(
                     body, id(immich_url).state, id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot0, id(espframe_core).slideshow().state().slot1, id(espframe_core).slideshow().state().slot2,
                     orientation);
                   if (img_url.empty()) {
+                    if (!metadata_response_valid) {
+                      clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
+                      ESP_LOGW("immich", "Metadata page response had an unknown shape");
+                      id(espframe_core).slideshow().state().diagnostic_reason = "metadata page response invalid";
+                      id(log_immich_diag).execute();
+                      id(immich_register_fetch_failure).execute();
+                      return;
+                    }
+                    if (metadata_item_count == 0 &&
+                        retry_empty_immich_metadata_page(id(immich_request_state))) {
+                      ESP_LOGD("immich", "Empty album metadata page; retrying page %d of %u (probe %u/%u)",
+                               id(immich_request_state).metadata_page,
+                               (unsigned) id(immich_request_state).metadata_max_page,
+                               (unsigned) id(immich_request_state).metadata_empty_page_probes,
+                               (unsigned) MAX_EMPTY_METADATA_PAGE_PROBES);
+                      id(immich_fetch_metadata_page_probe).execute();
+                      return;
+                    }
                     clear_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags);
-                    if (orientation != "Any" && id(immich_request_state).retry_available(MAX_ERROR_RETRIES)) {
+                    if (metadata_item_count > 0 && orientation != "Any" && id(immich_request_state).retry_available(MAX_ERROR_RETRIES)) {
                       id(immich_request_state).register_request_error();
                       ESP_LOGW("immich", "No %s image in metadata page; retrying", orientation.c_str());
                       id(immich_fetch_retry).execute();

--- a/components/espframe/immich_helpers.h
+++ b/components/espframe/immich_helpers.h
@@ -11,7 +11,9 @@
 static constexpr uint16_t ZOOM_IDENTITY = 256;
 static constexpr uint16_t IMMICH_ALBUM_PAGE_SIZE = 16;
 static constexpr uint16_t IMMICH_METADATA_PAGE_SIZE = 5;
-static constexpr uint8_t MAX_EMPTY_METADATA_PAGE_PROBES = 8;
+// Sixteen midpoint probes reduce a 10,000-page upper bound below one page,
+// covering very sparse date-filtered albums without a first-page bias.
+static constexpr uint8_t MAX_EMPTY_METADATA_PAGE_PROBES = 16;
 
 // Owns the complete state of the Immich request pipeline. Keeping these values
 // together makes reset, retry, and cooldown transitions atomic instead of
@@ -42,6 +44,16 @@ struct ImmichRequestState {
   int album_order_index = 0;
 
   void reset() { *this = ImmichRequestState{}; }
+
+  // Kept for the photo-source flush path. Album pagination no longer has a
+  // statistics fallback cache, but applying a source must still clear its
+  // in-progress page-bound probes.
+  void reset_album_metadata_fallbacks() {
+    this->metadata_max_page = 1;
+    this->metadata_empty_page_probes = 0;
+    this->metadata_page_bound_is_upper = false;
+    this->metadata_page1_fallback_attempted = false;
+  }
 
   void begin_memory_search() {
     this->memory_fallback = false;

--- a/components/espframe/immich_helpers.h
+++ b/components/espframe/immich_helpers.h
@@ -455,7 +455,9 @@ inline void initialize_immich_metadata_page_range(ImmichRequestState &state,
 // Album assetCount includes videos plus assets hidden by Immich or excluded by
 // Espframe's date filter. It is therefore an upper bound rather than an exact
 // metadata-search total. An empty metadata page proves every later page is
-// empty too, so reduce the range and sample again without changing albums.
+// empty too, so reduce the range and probe its midpoint without changing
+// albums. Midpoint probes converge on a selective filter's actual last page,
+// whereas repeated random probes can keep landing above that boundary.
 inline bool retry_empty_immich_metadata_page(ImmichRequestState &state) {
   if (!state.metadata_page_bound_is_upper) return false;
 
@@ -463,7 +465,7 @@ inline bool retry_empty_immich_metadata_page(ImmichRequestState &state) {
     uint32_t previous_page = static_cast<uint32_t>(state.metadata_page);
     state.metadata_max_page = std::min(state.metadata_max_page, previous_page - 1);
     if (state.metadata_max_page == 0) return false;
-    state.metadata_page = (esp_random() % state.metadata_max_page) + 1;
+    state.metadata_page = static_cast<int>((state.metadata_max_page + 1) / 2);
     state.metadata_empty_page_probes++;
     return true;
   }

--- a/components/espframe/immich_helpers.h
+++ b/components/espframe/immich_helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "date_utils.h"
 #include "esp_random.h"
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -10,6 +11,7 @@
 static constexpr uint16_t ZOOM_IDENTITY = 256;
 static constexpr uint16_t IMMICH_ALBUM_PAGE_SIZE = 16;
 static constexpr uint16_t IMMICH_METADATA_PAGE_SIZE = 5;
+static constexpr uint8_t MAX_EMPTY_METADATA_PAGE_PROBES = 8;
 
 // Owns the complete state of the Immich request pipeline. Keeping these values
 // together makes reset, retry, and cooldown transitions atomic instead of
@@ -32,6 +34,10 @@ struct ImmichRequestState {
   std::string metadata_tag_ids;
   int metadata_page = 1;
   int metadata_page_size = 1;
+  uint32_t metadata_max_page = 1;
+  uint8_t metadata_empty_page_probes = 0;
+  bool metadata_page_bound_is_upper = false;
+  bool metadata_page1_fallback_attempted = false;
   uint32_t metadata_bypass_until_ms = 0;
   int album_order_index = 0;
 
@@ -97,6 +103,10 @@ struct ImmichRequestState {
     this->clear_failures();
     this->retry_delay_ms = 2000;
     this->retry_cooldown_until_ms = 0;
+    this->metadata_max_page = 1;
+    this->metadata_empty_page_probes = 0;
+    this->metadata_page_bound_is_upper = false;
+    this->metadata_page1_fallback_attempted = false;
   }
 
   int register_request_error() { return ++this->api_retries; }
@@ -420,6 +430,53 @@ inline uint32_t immich_metadata_page_for_total(uint32_t total,
   return (esp_random() % pages) + 1;
 }
 
+inline uint32_t immich_metadata_page_count_for_total(uint32_t total,
+                                                      uint16_t page_size = IMMICH_METADATA_PAGE_SIZE) {
+  if (page_size == 0) page_size = IMMICH_METADATA_PAGE_SIZE;
+  if (total == 0) return 1;
+  uint32_t pages = (total + page_size - 1) / page_size;
+  if (pages == 0) pages = 1;
+  return pages;
+}
+
+inline void initialize_immich_metadata_page_range(ImmichRequestState &state,
+                                                   uint32_t total,
+                                                   uint16_t page_size,
+                                                   bool count_is_upper_bound) {
+  if (page_size == 0) page_size = IMMICH_METADATA_PAGE_SIZE;
+  state.metadata_page_size = page_size;
+  state.metadata_max_page = immich_metadata_page_count_for_total(total, page_size);
+  state.metadata_page = (esp_random() % state.metadata_max_page) + 1;
+  state.metadata_empty_page_probes = 0;
+  state.metadata_page_bound_is_upper = count_is_upper_bound;
+  state.metadata_page1_fallback_attempted = false;
+}
+
+// Album assetCount includes videos plus assets hidden by Immich or excluded by
+// Espframe's date filter. It is therefore an upper bound rather than an exact
+// metadata-search total. An empty metadata page proves every later page is
+// empty too, so reduce the range and sample again without changing albums.
+inline bool retry_empty_immich_metadata_page(ImmichRequestState &state) {
+  if (!state.metadata_page_bound_is_upper) return false;
+
+  if (state.metadata_page > 1 && state.metadata_empty_page_probes < MAX_EMPTY_METADATA_PAGE_PROBES) {
+    uint32_t previous_page = static_cast<uint32_t>(state.metadata_page);
+    state.metadata_max_page = std::min(state.metadata_max_page, previous_page - 1);
+    if (state.metadata_max_page == 0) return false;
+    state.metadata_page = (esp_random() % state.metadata_max_page) + 1;
+    state.metadata_empty_page_probes++;
+    return true;
+  }
+
+  if (!state.metadata_page1_fallback_attempted && state.metadata_page != 1) {
+    state.metadata_page = 1;
+    state.metadata_page1_fallback_attempted = true;
+    return true;
+  }
+
+  return false;
+}
+
 inline bool immich_source_uses_metadata_search(const std::string &photo_source) {
   return photo_source == "Album" || photo_source == "Person" || photo_source == "Tag";
 }
@@ -697,6 +754,46 @@ inline uint32_t parse_immich_statistics_total(const std::string &body) {
   if (root["total"].is<int>()) total = root["total"].as<int>();
   if (total <= 0 && root["images"].is<int>()) total = root["images"].as<int>();
   return total > 0 ? static_cast<uint32_t>(total) : 0;
+}
+
+inline bool parse_immich_album_asset_count(const std::string &body, uint32_t *out_count) {
+  if (out_count == nullptr) return false;
+  auto doc = esphome::json::parse_json(body);
+  if (doc.isNull() || !doc.is<JsonObject>()) return false;
+
+  JsonObject root = doc.as<JsonObject>();
+  if (!root["assetCount"].is<int>()) return false;
+  int count = root["assetCount"].as<int>();
+  if (count < 0) return false;
+  *out_count = static_cast<uint32_t>(count);
+  return true;
+}
+
+// Return true only when the response has a recognised metadata result shape.
+// This lets the caller distinguish an empty result page from malformed JSON or
+// a page whose images simply do not match the requested orientation.
+inline bool parse_immich_metadata_item_count(const std::string &body, size_t *out_count) {
+  if (out_count == nullptr) return false;
+  auto doc = esphome::json::parse_json(body);
+  if (doc.isNull()) return false;
+
+  if (doc.is<JsonArray>()) {
+    *out_count = doc.as<JsonArray>().size();
+    return true;
+  }
+  if (!doc.is<JsonObject>()) return false;
+
+  JsonObject root = doc.as<JsonObject>();
+  JsonObject assets = root["assets"].as<JsonObject>();
+  if (assets.isNull()) return false;
+
+  JsonArray items = assets["items"].as<JsonArray>();
+  if (items.isNull() && assets["assets"].is<JsonArray>()) {
+    items = assets["assets"].as<JsonArray>();
+  }
+  if (items.isNull()) return false;
+  *out_count = items.size();
+  return true;
 }
 
 inline std::string parse_immich_metadata_asset(const std::string &body,

--- a/docs/photo-sources.md
+++ b/docs/photo-sources.md
@@ -40,6 +40,7 @@ Shows photos from one or more Immich albums. **Get the UUID:** open the album in
 The descriptions are saved with the IDs so the web UI can show friendly labels later. They do not affect which photos Immich returns.
 
 Album photos are sampled through paged Immich search, so large albums are not limited to the first small batch of results.
+Shared albums are sampled across photos added by every contributor, not only the account used by the frame's API key.
 
 When you add more than one album, **Album Order** can either keep sampling albums randomly or cycle through the Albums list from top to bottom. Use the move buttons beside each album to set the list order. Photos inside each selected album are still chosen randomly.
 

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -228,7 +228,7 @@ static void test_immich_body_helpers() {
   metadata_state.metadata_max_page = 151;
   assert(retry_empty_immich_metadata_page(metadata_state));
   assert(metadata_state.metadata_max_page == 150);
-  assert(metadata_state.metadata_page == 1);
+  assert(metadata_state.metadata_page == 75);
   assert(metadata_state.metadata_empty_page_probes == 1);
   // Probing is internal to the chosen album; it must not advance list order.
   assert(album_order_index == 1);

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -290,12 +290,6 @@ static void test_immich_body_helpers() {
   assert(build_immich_statistics_search_body("Tag", "", "", "t1,t2")
              .find("\"tagIds\":[\"t1\",\"t2\"]") != std::string::npos);
 
-  assert(parse_immich_metadata_next_page_value("7") == 7);
-  assert(parse_immich_metadata_next_page_value("3") == 3);
-  assert(parse_immich_metadata_next_page_value("") == 0);
-  assert(parse_immich_metadata_next_page_value("null") == 0);
-  assert(parse_immich_metadata_next_page_value("1x") == 0);
-
   std::vector<ImmichTimelineBucketInfo> large_album_buckets = {
       {"2026-05-01", 848},
       {"2026-04-01", 12},
@@ -342,46 +336,6 @@ static void test_immich_request_state() {
   assert(state.memory_asset_id == "asset-b");
   assert(state.advance_memory_window());
   assert(state.memory_window_offset == -1);
-
-  state.metadata_album_id = "album-a";
-  state.begin_album_statistics_probe();
-  assert(state.metadata_album_fallback);
-  assert(state.metadata_album_statistics_probe);
-  assert(state.metadata_page == 1);
-  assert(state.metadata_page_size == IMMICH_METADATA_PAGE_SIZE);
-  assert(state.finish_album_metadata_page(true, 4, 1000));
-  assert(state.album_metadata_fallback_active("album-a", 1001));
-  state.begin_album_metadata_fallback("album-a");
-  assert(state.metadata_page == 4);
-  assert(!state.metadata_album_statistics_probe);
-  state.retry_album_metadata_fallback();
-  assert(state.should_resume_album_metadata_fallback(1002));
-  state.clear_album_metadata_fallback_request();
-  assert(!state.should_resume_album_metadata_fallback(1002));
-
-  state.metadata_album_id = "album-b";
-  state.begin_album_statistics_probe();
-  assert(state.finish_album_metadata_page(true, 2, 2000));
-  state.begin_album_metadata_fallback("album-b");
-  assert(state.metadata_page == 2);
-  state.begin_album_metadata_fallback("album-a");
-  assert(state.metadata_page == 4);
-
-  state.metadata_album_id = "album-a";
-  state.begin_album_metadata_fallback("album-a");
-  assert(!state.finish_album_metadata_page(true, 0, 3000));
-  state.begin_album_metadata_fallback("album-a");
-  assert(state.metadata_page == 1);
-  assert(!state.album_metadata_fallback_active("album-a", 1000 + IMMICH_ALBUM_METADATA_FALLBACK_MS));
-
-  state.metadata_album_id = "empty-album";
-  state.begin_album_statistics_probe();
-  assert(!state.finish_album_metadata_page(false, 0, 4000));
-  assert(!state.album_metadata_fallback_active("empty-album", 4001));
-
-  state.reset_album_metadata_fallbacks();
-  assert(!state.album_metadata_fallback_active("album-a", 3001));
-  assert(!state.album_metadata_fallback_active("album-b", 3001));
 
   assert(state.register_request_error() == 1);
   assert(state.prepare_retry_delay() == 2000);

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -215,6 +215,45 @@ static void test_immich_body_helpers() {
   assert(immich_metadata_page_for_total(0) == 1);
   assert(immich_metadata_page_for_total(848) == 1);
   assert(immich_metadata_page_for_total(848, 5) <= 170);
+  assert(immich_metadata_page_count_for_total(0) == 1);
+  assert(immich_metadata_page_count_for_total(753, 1) == 753);
+  assert(immich_metadata_page_count_for_total(753, 5) == 151);
+  ImmichRequestState metadata_state;
+  initialize_immich_metadata_page_range(metadata_state, 753, 1, true);
+  assert(metadata_state.metadata_page_size == 1);
+  assert(metadata_state.metadata_max_page == 753);
+  assert(metadata_state.metadata_page == 1);
+  assert(metadata_state.metadata_page_bound_is_upper);
+  metadata_state.metadata_page = 151;
+  metadata_state.metadata_max_page = 151;
+  assert(retry_empty_immich_metadata_page(metadata_state));
+  assert(metadata_state.metadata_max_page == 150);
+  assert(metadata_state.metadata_page == 1);
+  assert(metadata_state.metadata_empty_page_probes == 1);
+  // Probing is internal to the chosen album; it must not advance list order.
+  assert(album_order_index == 1);
+  metadata_state.metadata_page = 10;
+  metadata_state.metadata_max_page = 10;
+  for (uint8_t probe = metadata_state.metadata_empty_page_probes;
+       probe < MAX_EMPTY_METADATA_PAGE_PROBES; probe++) {
+    metadata_state.metadata_page = 10;
+    metadata_state.metadata_max_page = 10;
+    assert(retry_empty_immich_metadata_page(metadata_state));
+  }
+  assert(metadata_state.metadata_empty_page_probes == MAX_EMPTY_METADATA_PAGE_PROBES);
+  metadata_state.metadata_page = 42;
+  metadata_state.metadata_empty_page_probes = MAX_EMPTY_METADATA_PAGE_PROBES;
+  assert(retry_empty_immich_metadata_page(metadata_state));
+  assert(metadata_state.metadata_page == 1);
+  assert(metadata_state.metadata_page1_fallback_attempted);
+  assert(!retry_empty_immich_metadata_page(metadata_state));
+  metadata_state.register_success();
+  assert(metadata_state.metadata_empty_page_probes == 0);
+  assert(!metadata_state.metadata_page_bound_is_upper);
+  assert(!metadata_state.metadata_page1_fallback_attempted);
+  initialize_immich_metadata_page_range(metadata_state, 109, 5, false);
+  assert(metadata_state.metadata_max_page == 22);
+  assert(!retry_empty_immich_metadata_page(metadata_state));
   assert(!immich_source_uses_metadata_search("All Photos"));
   assert(!immich_source_uses_metadata_search("Favorites"));
   assert(immich_source_uses_metadata_search("Album"));


### PR DESCRIPTION
Fixes #144

## What changed

- Album slideshows now use the selected album's `assetCount`, which includes shared-album contributors, instead of account-scoped search statistics.
- The count is treated as an upper bound: confirmed empty metadata pages reduce the page range and retry internally, while non-empty orientation misses retain the existing retry flow.
- Shared-album behavior is documented.

## Verification

- `npm run test:helpers`
- `npm run check:product`
- `npm run check:pr`
- Compiled both supported 10-inch factory firmware configurations.