### PR TITLE
Update ESPHome to 2026.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ npm ci
 npm run docs:dev
 
 # Compile firmware locally
-docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.6.5 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
-docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.6.5 compile /config/builds/guition-esp32-p4-jc8012p4a1-v2.factory.yaml
+docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.7.4 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
+docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.7.4 compile /config/builds/guition-esp32-p4-jc8012p4a1-v2.factory.yaml
 ```
 
 ### In-Development Firmware Features

--- a/docs/install.md
+++ b/docs/install.md
@@ -59,4 +59,4 @@ Choose whether the on-screen clock uses a 24-hour or 12-hour format.
 
 - **Multiple Album, Person, or Tag IDs:** Saving comma-separated UUID lists uses a POST body so long lists no longer hit **414 URI Too Long**. Album IDs, Person IDs, and Tag IDs are still limited to **255 characters** each; see [Photo Sources](/photo-sources#album-person-and-tag-id-limits).
 - **Photo date filters:** The web UI now supports fixed date ranges and rolling ranges such as the last 6 months or last 2 years. See [Photo Sources](/photo-sources#date-filtering).
-- **ESPHome 2026.6:** Current local builds use ESPHome `2026.6.5`; manual builds also include compatibility fixes for ESPHome 2026.3 and 2026.4 LVGL changes.
+- **ESPHome 2026.7:** Current local builds use ESPHome `2026.7.4`; manual builds also include compatibility fixes for ESPHome 2026.3, 2026.4, and 2026.7 LVGL changes.

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -63,7 +63,7 @@ esphome run esphome.yaml
 First build takes a few minutes; OTA updates are faster.
 
 ::: info ESPHome version
-Current local builds use ESPHome `2026.6.5`. The shared configuration includes compatibility fixes for ESPHome 2026.3 and 2026.4 LVGL changes.
+Current local builds use ESPHome `2026.7.4`. The shared configuration includes compatibility fixes for ESPHome 2026.3, 2026.4, and 2026.7 LVGL changes.
 :::
 
 ## Substitutions

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -88,7 +88,7 @@ RAM, and binary budgets, and uploads a `firmware-test-<device>` artifact contain
 To run the same factory compile locally with Docker:
 
 ```sh
-docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.6.5 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
+docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.7.4 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
 ```
 
 Use a full compile before firmware releases, after changing ESPHome YAML, after changing C++ code that is not covered by the host-side helper tests, and whenever you want a branch firmware build to flash to a test display.

--- a/product/contract/project.json
+++ b/product/contract/project.json
@@ -1575,5 +1575,5 @@
   "esphome_docker_image": "ghcr.io/esphome/esphome",
   "esphome_config_mount": "/config",
   "esphome_docker_remove_container": true,
-  "esphome_version": "2026.6.5"
+  "esphome_version": "2026.7.4"
 }

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -1576,7 +1576,7 @@
     "esphome_docker_image": "ghcr.io/esphome/esphome",
     "esphome_config_mount": "/config",
     "esphome_docker_remove_container": true,
-    "esphome_version": "2026.6.5"
+    "esphome_version": "2026.7.4"
   },
   "devices": [
     {


### PR DESCRIPTION
Updates the shared ESPHome Docker image pin to 2026.7.4 and regenerates the product metadata.

The local build commands and setup documentation now use the same version.

Validation:
- `npm run check:fast`
- Factory firmware compiled successfully for `guition-esp32-p4-jc8012p4a1`
- ESPHome 2026.7.4 configuration validation passed for OTA and factory builds on both supported displays

The complete release-readiness script was also attempted; it stopped before compilation because the browser-smoke Chrome subprocess aborted and the script requires a clean working tree.