### PR TITLE
Support TLS 1.3 reverse proxies

### DIFF
--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -25,6 +25,9 @@ esp32:
       CONFIG_HTTPD_MAX_REQ_HDR_LEN: "8192"
       CONFIG_HTTPD_MAX_URI_LEN: "128"
       CONFIG_ESP_TASK_WDT_TIMEOUT_S: "30"
+      # Some modern reverse proxies offer TLS 1.3 only. Enable it alongside
+      # TLS 1.2 so HTTPS photo downloads work with those servers.
+      CONFIG_MBEDTLS_SSL_PROTO_TLS1_3: "y"
     advanced:
       enable_idf_experimental_features: true
 

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -25,6 +25,9 @@ esp32:
       CONFIG_HTTPD_MAX_REQ_HDR_LEN: "8192"
       CONFIG_HTTPD_MAX_URI_LEN: "128"
       CONFIG_ESP_TASK_WDT_TIMEOUT_S: "30"
+      # Some modern reverse proxies offer TLS 1.3 only. Enable it alongside
+      # TLS 1.2 so HTTPS photo downloads work with those servers.
+      CONFIG_MBEDTLS_SSL_PROTO_TLS1_3: "y"
     advanced:
       enable_idf_experimental_features: true
 


### PR DESCRIPTION
Fixes #157.

## Summary

- Enable TLS 1.3 for both ESP32-P4 display firmware profiles.
- Keep TLS 1.2 enabled, so existing Immich servers continue to work.

## Why

ESPHome’s ESP32-P4 build currently offers TLS 1.2 only. Some HTTPS reverse proxies are configured for TLS 1.3, which causes photo downloads to fail during the TLS handshake.

## Validation

- ESPHome 2026.7.4 configuration validation passed for both factory firmware profiles.
- `npm run check:fast` passed.
- PR Validation passed.
- Firmware compilation is skipped by the PR workflow; it remains available through the workflow dispatch build.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Existing setup instructions already cover HTTPS; no new setting or user action is required.