### PR TITLE
Fix ESPHome firmware artifact paths

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -98,7 +98,7 @@ jobs:
             compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml" \
             2>&1 | tee "output/${{ matrix.slug }}.factory.log"
 
-          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/.pioenvs/${{ matrix.build_name }}"
+          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}"
           if [ ! -f "${BUILD_DIR}/firmware.factory.bin" ]; then
             echo "::error::Firmware compilation failed - factory binary not found"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
             compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml" \
             2>&1 | tee "output/${{ matrix.slug }}.factory.log"
 
-          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/.pioenvs/${{ matrix.build_name }}"
+          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}"
           if [ ! -f "${BUILD_DIR}/firmware.factory.bin" ]; then
             echo "::error::Firmware compilation failed - factory binary not found"
             exit 1
@@ -145,7 +145,7 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
-          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/.pioenvs/${{ matrix.build_name }}"
+          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}"
           mkdir -p output
 
           if [ ! -f "${BUILD_DIR}/firmware.bin" ]; then

--- a/scripts/check_release_ready.py
+++ b/scripts/check_release_ready.py
@@ -86,7 +86,10 @@ def compile_firmware() -> bool:
         if not cache_dir or not build_name:
             print(f"[FAIL] Firmware budget metadata ({device['slug']})")
             return False
-        build_dir = ROOT / cache_dir / "build" / build_name / ".pioenvs" / build_name
+        # ESPHome 2026 writes firmware artifacts directly into the named
+        # ESP-IDF build directory; PlatformIO's former .pioenvs subdirectory
+        # is no longer created.
+        build_dir = ROOT / cache_dir / "build" / build_name
         factory_command = esphome_compile_command(
             image,
             version,

--- a/scripts/product_contract/workflows.py
+++ b/scripts/product_contract/workflows.py
@@ -1767,10 +1767,7 @@ def check_device_workflow_contract(product: dict, errors: list[str]) -> None:
             errors,
         )
     if release_esphome_cache_dir:
-        build_dir_fragment = (
-            'BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/.pioenvs/'
-            '${{ matrix.build_name }}"'
-        )
+        build_dir_fragment = 'BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}"'
         for target, step_names in (
             ("compile.compile", ("Compile test firmware artifacts",)),
             ("release.build-firmware", ("Compile firmware", "Collect firmware files and generate manifest")),

--- a/tests/release_ready_tests.py
+++ b/tests/release_ready_tests.py
@@ -62,10 +62,10 @@ def test_compile_firmware_runs_versioned_factory_and_ota_commands() -> None:
     ]
     assert_versioned_compile(captured[0][1], "/config/builds/test-frame.factory.yaml")
     assert captured[1][1][-4:-2] == ["--profile", "factory"]
-    assert captured[1][1][-1].endswith("test-frame-build/firmware.factory.bin")
+    assert captured[1][1][-1].endswith("build/test-frame-build/firmware.factory.bin")
     assert_versioned_compile(captured[2][1], "/config/builds/test-frame.yaml")
     assert captured[3][1][-4:-2] == ["--profile", "ota"]
-    assert captured[3][1][-1].endswith("test-frame-build/firmware.bin")
+    assert captured[3][1][-1].endswith("build/test-frame-build/firmware.bin")
 
 
 def test_compile_firmware_rejects_missing_metadata() -> None:


### PR DESCRIPTION
## Summary
- read ESPHome 2026 firmware artifacts from the current ESP-IDF build directory
- update compile and release workflows to upload the current artifact locations
- keep workflow contract validation aligned with the release checker

## Verification
- `npm run test:release-ready`
- `npm run test:workflow-contract`
- `npm run check:product`
- `npm run check:firmware-release`

The compile-aware release check reproduced the old artifact-path failure after successfully compiling firmware.