### PR TITLE
Fix browser smoke timeout on Chrome 151

### DIFF
--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -1370,7 +1370,10 @@ async function runScenario(scenario) {
       ...chromeSandboxArgs(),
       `--user-data-dir=${userDataDir}`,
       `--window-size=${scenario.width},${scenario.height}`,
-      "--virtual-time-budget=16000",
+      // Chrome 151 can keep virtual time paused while an internal background
+      // request is pending. A real timeout still lets the app's asynchronous
+      // assertions settle, then reliably captures the resulting DOM.
+      "--timeout=16000",
       "--dump-dom",
       `file://${htmlPath}${query}`,
     ],


### PR DESCRIPTION
## What changed

- Replace the virtual-time budget with Chrome's real capture timeout in the browser smoke runner.

## Why

Chrome 151 can leave virtual time paused while an internal background request is pending. This caused the browser smoke test to time out before it could capture the page result.

## Validation

- `npm run test:web-smoke-cli`
- GitHub PR Validation is running against this branch.