### PR TITLE
Fix ESPHome 2026 firmware artifact paths

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -98,7 +98,7 @@ jobs:
             compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml" \
             2>&1 | tee "output/${{ matrix.slug }}.factory.log"
 
-          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}"
+          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"
           if [ ! -f "${BUILD_DIR}/firmware.factory.bin" ]; then
             echo "::error::Firmware compilation failed - factory binary not found"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
             compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml" \
             2>&1 | tee "output/${{ matrix.slug }}.factory.log"
 
-          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}"
+          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"
           if [ ! -f "${BUILD_DIR}/firmware.factory.bin" ]; then
             echo "::error::Firmware compilation failed - factory binary not found"
             exit 1
@@ -145,7 +145,7 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
-          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}"
+          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"
           mkdir -p output
 
           if [ ! -f "${BUILD_DIR}/firmware.bin" ]; then

--- a/scripts/check_release_ready.py
+++ b/scripts/check_release_ready.py
@@ -86,10 +86,10 @@ def compile_firmware() -> bool:
         if not cache_dir or not build_name:
             print(f"[FAIL] Firmware budget metadata ({device['slug']})")
             return False
-        # ESPHome 2026 writes firmware artifacts directly into the named
-        # ESP-IDF build directory; PlatformIO's former .pioenvs subdirectory
-        # is no longer created.
-        build_dir = ROOT / cache_dir / "build" / build_name
+        # ESPHome 2026 writes firmware artifacts into ESP-IDF's `build`
+        # subdirectory; PlatformIO's former .pioenvs directory is no longer
+        # created.
+        build_dir = ROOT / cache_dir / "build" / build_name / "build"
         factory_command = esphome_compile_command(
             image,
             version,

--- a/scripts/product_contract/workflows.py
+++ b/scripts/product_contract/workflows.py
@@ -1767,7 +1767,7 @@ def check_device_workflow_contract(product: dict, errors: list[str]) -> None:
             errors,
         )
     if release_esphome_cache_dir:
-        build_dir_fragment = 'BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}"'
+        build_dir_fragment = 'BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"'
         for target, step_names in (
             ("compile.compile", ("Compile test firmware artifacts",)),
             ("release.build-firmware", ("Compile firmware", "Collect firmware files and generate manifest")),

--- a/tests/release_ready_tests.py
+++ b/tests/release_ready_tests.py
@@ -62,10 +62,10 @@ def test_compile_firmware_runs_versioned_factory_and_ota_commands() -> None:
     ]
     assert_versioned_compile(captured[0][1], "/config/builds/test-frame.factory.yaml")
     assert captured[1][1][-4:-2] == ["--profile", "factory"]
-    assert captured[1][1][-1].endswith("build/test-frame-build/firmware.factory.bin")
+    assert captured[1][1][-1].endswith("build/test-frame-build/build/firmware.factory.bin")
     assert_versioned_compile(captured[2][1], "/config/builds/test-frame.yaml")
     assert captured[3][1][-4:-2] == ["--profile", "ota"]
-    assert captured[3][1][-1].endswith("build/test-frame-build/firmware.bin")
+    assert captured[3][1][-1].endswith("build/test-frame-build/build/firmware.bin")
 
 
 def test_compile_firmware_rejects_missing_metadata() -> None:

--- a/tests/workflow_contract_tests.py
+++ b/tests/workflow_contract_tests.py
@@ -1697,6 +1697,15 @@ def test_workflow_named_step_run_contains_checks_compile_artifact_step() -> None
     ]
 
 
+def test_workflows_use_esphome_2026_build_artifact_directory() -> None:
+    artifact_dir = 'BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"'
+    compile_workflow = (ROOT / ".github" / "workflows" / "compile.yml").read_text()
+    release_workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+
+    assert artifact_dir in compile_workflow
+    assert release_workflow.count(artifact_dir) == 2
+
+
 def test_workflow_named_step_run_contains_checks_compile_commands() -> None:
     errors: list[str] = []
     workflow_texts = {


### PR DESCRIPTION
## What changed

- Read ESPHome 2026 factory and OTA files from each ESP-IDF build subdirectory.
- Keep the local release-readiness checker and both GitHub firmware workflows aligned.
- Add regression coverage for the workflow artifact location.

## Why

Firmware compilation succeeds, but ESPHome 2026 writes the output files under `build/<device>/build/`. The workflows checked the parent directory, causing the release gate to fail after compiling.

## Validation

- `npm run test:release-ready`
- `npm run test:workflow-contract`
- `npm run check:firmware-release`
- GitHub PR Validation is running against this branch.