### PR TITLE
Align ESPHome 2026 OTA artifacts and RAM budget

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -116,15 +116,15 @@ jobs:
             compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.yaml" \
             2>&1 | tee "output/${{ matrix.slug }}.ota.log"
 
-          if [ ! -f "${BUILD_DIR}/firmware.bin" ]; then
+          if [ ! -f "${BUILD_DIR}/firmware.ota.bin" ]; then
             echo "::error::Firmware compilation failed - OTA binary not found"
             exit 1
           fi
-          sudo cp "${BUILD_DIR}/firmware.bin" "output/${{ matrix.slug }}.ota.bin"
+          sudo cp "${BUILD_DIR}/firmware.ota.bin" "output/${{ matrix.slug }}.ota.bin"
           python3 scripts/check_build_budgets.py \
             --compile-log "output/${{ matrix.slug }}.ota.log" \
             --profile ota \
-            --binary "${BUILD_DIR}/firmware.bin"
+            --binary "${BUILD_DIR}/firmware.ota.bin"
 
           {
             echo "version=${TEST_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,14 +124,14 @@ jobs:
             compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.yaml" \
             2>&1 | tee "output/${{ matrix.slug }}.ota.log"
 
-          if [ ! -f "${BUILD_DIR}/firmware.bin" ]; then
+          if [ ! -f "${BUILD_DIR}/firmware.ota.bin" ]; then
             echo "::error::Firmware compilation failed - OTA binary not found"
             exit 1
           fi
           python3 scripts/check_build_budgets.py \
             --compile-log "output/${{ matrix.slug }}.ota.log" \
             --profile ota \
-            --binary "${BUILD_DIR}/firmware.bin"
+            --binary "${BUILD_DIR}/firmware.ota.bin"
 
       - name: Fix ESPHome cache permissions
         if: always()
@@ -148,12 +148,12 @@ jobs:
           BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"
           mkdir -p output
 
-          if [ ! -f "${BUILD_DIR}/firmware.bin" ]; then
+          if [ ! -f "${BUILD_DIR}/firmware.ota.bin" ]; then
             echo "::error::Firmware compilation failed - OTA binary not found"
             exit 1
           fi
 
-          sudo cp "${BUILD_DIR}/firmware.bin" "output/${{ matrix.slug }}.ota.bin"
+          sudo cp "${BUILD_DIR}/firmware.ota.bin" "output/${{ matrix.slug }}.ota.bin"
 
           python3 scripts/firmware_release.py manifest \
             --slug "${{ matrix.slug }}" \

--- a/product/budgets.json
+++ b/product/budgets.json
@@ -12,15 +12,15 @@
     "factory": {
       "flash_used_bytes_max": 2950000,
       "flash_used_percent_max": 36.0,
-      "ram_used_bytes_max": 92160,
-      "ram_used_percent_max": 18.0,
+      "ram_used_bytes_max": 147456,
+      "ram_used_percent_max": 25.0,
       "binary_bytes_max": 3000000
     },
     "ota": {
       "flash_used_bytes_max": 2950000,
       "flash_used_percent_max": 36.0,
-      "ram_used_bytes_max": 92160,
-      "ram_used_percent_max": 18.0,
+      "ram_used_bytes_max": 147456,
+      "ram_used_percent_max": 25.0,
       "binary_bytes_max": 2900000
     }
   }

--- a/product/contract/project.json
+++ b/product/contract/project.json
@@ -1143,7 +1143,7 @@
   "release_publish_dir": "firmware",
   "release_uploaded_verify_dir": "published",
   "release_source_factory_binary": "firmware.factory.bin",
-  "release_source_ota_binary": "firmware.bin",
+  "release_source_ota_binary": "firmware.ota.bin",
   "release_asset_suffixes": [
     ".factory.bin",
     ".ota.bin",

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -1144,7 +1144,7 @@
     "release_publish_dir": "firmware",
     "release_uploaded_verify_dir": "published",
     "release_source_factory_binary": "firmware.factory.bin",
-    "release_source_ota_binary": "firmware.bin",
+    "release_source_ota_binary": "firmware.ota.bin",
     "release_asset_suffixes": [
       ".factory.bin",
       ".ota.bin",

--- a/scripts/check_release_ready.py
+++ b/scripts/check_release_ready.py
@@ -128,7 +128,7 @@ def compile_firmware() -> bool:
                     "--profile",
                     "ota",
                     "--binary",
-                    str(build_dir / "firmware.bin"),
+                    str(build_dir / "firmware.ota.bin"),
                 ],
                 f"Firmware OTA budget ({device['slug']})",
             )

--- a/tests/release_ready_tests.py
+++ b/tests/release_ready_tests.py
@@ -65,7 +65,7 @@ def test_compile_firmware_runs_versioned_factory_and_ota_commands() -> None:
     assert captured[1][1][-1].endswith("build/test-frame-build/build/firmware.factory.bin")
     assert_versioned_compile(captured[2][1], "/config/builds/test-frame.yaml")
     assert captured[3][1][-4:-2] == ["--profile", "ota"]
-    assert captured[3][1][-1].endswith("build/test-frame-build/build/firmware.bin")
+    assert captured[3][1][-1].endswith("build/test-frame-build/build/firmware.ota.bin")
 
 
 def test_compile_firmware_rejects_missing_metadata() -> None:

--- a/tests/workflow_contract_tests.py
+++ b/tests/workflow_contract_tests.py
@@ -1491,7 +1491,7 @@ def test_workflow_named_step_run_contains_checks_firmware_build_steps() -> None:
         "release.build-firmware",
         "Collect firmware files and generate manifest",
         [
-            '"${BUILD_DIR}/firmware.bin"',
+            '"${BUILD_DIR}/firmware.ota.bin"',
             '"output/${{ matrix.slug }}.manifest.json"',
             '--factory "output/${{ matrix.slug }}.factory.bin"',
         ],
@@ -1503,6 +1503,10 @@ def test_workflow_named_step_run_contains_checks_firmware_build_steps() -> None:
         (
             "release.yml job build-firmware step 'Compile firmware' run is missing "
             "'\"${BUILD_DIR}/firmware.factory.bin\"'"
+        ),
+        (
+            "release.yml job build-firmware step 'Collect firmware files and generate manifest' "
+            "run is missing '\"${BUILD_DIR}/firmware.ota.bin\"'"
         ),
         (
             "release.yml job build-firmware step 'Collect firmware files and generate manifest' "


### PR DESCRIPTION
## What changed

- Read ESPHome 2026 OTA firmware from `firmware.ota.bin`.
- Update the generated product metadata and release-readiness checker.
- Set the firmware RAM safety cap to 25% (147,456 bytes), above the verified 22.9% usage while retaining substantial headroom.

## Validation

- `npm run check:generated`
- `npm run check:product`
- `npm run test:release-ready`
- `npm run test:workflow-contract`
- `npm run test:budgets`
- `npm run check:firmware-release`