### PR TITLE
Show install button after firmware update check

### DIFF
--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -3278,7 +3278,7 @@ to {
   function firmwareUpdateKnownAvailable() {
     var installed = installedFirmwareVersion();
     var latest = String(S.latest_version || "").trim();
-    return compareFirmwareVersions(latest, installed) > 0;
+    return !!S.update_available || compareFirmwareVersions(latest, installed) > 0;
   }
   function c6FirmwareUpdateKnownAvailable() {
     var current = String(S.c6_current_firmware || "").trim();
@@ -3390,7 +3390,7 @@ to {
     if (!data) return false;
     if (data.current_version) S.installed_version = String(data.current_version);
     if (data.latest_version || data.value) S.latest_version = String(data.latest_version || data.value);
-    S.update_available = data.state === "UPDATE AVAILABLE" || firmwareUpdateKnownAvailable();
+    S.update_available = data.state === "UPDATE AVAILABLE" || compareFirmwareVersions(S.latest_version, installedFirmwareVersion()) > 0;
     refreshFirmwareUi();
     return S.update_available;
   }

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -3278,7 +3278,8 @@ to {
   function firmwareUpdateKnownAvailable() {
     var installed = installedFirmwareVersion();
     var latest = String(S.latest_version || "").trim();
-    return !!S.update_available || compareFirmwareVersions(latest, installed) > 0;
+    var comparison = compareFirmwareVersions(latest, installed);
+    return comparison === null ? !!S.update_available : comparison > 0;
   }
   function c6FirmwareUpdateKnownAvailable() {
     var current = String(S.c6_current_firmware || "").trim();
@@ -3390,7 +3391,8 @@ to {
     if (!data) return false;
     if (data.current_version) S.installed_version = String(data.current_version);
     if (data.latest_version || data.value) S.latest_version = String(data.latest_version || data.value);
-    S.update_available = data.state === "UPDATE AVAILABLE" || compareFirmwareVersions(S.latest_version, installedFirmwareVersion()) > 0;
+    var comparison = compareFirmwareVersions(S.latest_version, installedFirmwareVersion());
+    S.update_available = comparison === null ? data.state === "UPDATE AVAILABLE" : comparison > 0;
     refreshFirmwareUi();
     return S.update_available;
   }

--- a/docs/webserver/src/settings_firmware_card.ts
+++ b/docs/webserver/src/settings_firmware_card.ts
@@ -135,7 +135,7 @@
   function firmwareUpdateKnownAvailable() {
     var installed = installedFirmwareVersion();
     var latest = String(S.latest_version || "").trim();
-    return compareFirmwareVersions(latest, installed) > 0;
+    return !!S.update_available || compareFirmwareVersions(latest, installed) > 0;
   }
 
   function c6FirmwareUpdateKnownAvailable() {
@@ -253,7 +253,8 @@
     if (!data) return false;
     if (data.current_version) S.installed_version = String(data.current_version);
     if (data.latest_version || data.value) S.latest_version = String(data.latest_version || data.value);
-    S.update_available = data.state === "UPDATE AVAILABLE" || firmwareUpdateKnownAvailable();
+    S.update_available = data.state === "UPDATE AVAILABLE" ||
+      compareFirmwareVersions(S.latest_version, installedFirmwareVersion()) > 0;
     refreshFirmwareUi();
     return S.update_available;
   }

--- a/docs/webserver/src/settings_firmware_card.ts
+++ b/docs/webserver/src/settings_firmware_card.ts
@@ -135,7 +135,8 @@
   function firmwareUpdateKnownAvailable() {
     var installed = installedFirmwareVersion();
     var latest = String(S.latest_version || "").trim();
-    return !!S.update_available || compareFirmwareVersions(latest, installed) > 0;
+    var comparison = compareFirmwareVersions(latest, installed);
+    return comparison === null ? !!S.update_available : comparison > 0;
   }
 
   function c6FirmwareUpdateKnownAvailable() {
@@ -253,8 +254,8 @@
     if (!data) return false;
     if (data.current_version) S.installed_version = String(data.current_version);
     if (data.latest_version || data.value) S.latest_version = String(data.latest_version || data.value);
-    S.update_available = data.state === "UPDATE AVAILABLE" ||
-      compareFirmwareVersions(S.latest_version, installedFirmwareVersion()) > 0;
+    var comparison = compareFirmwareVersions(S.latest_version, installedFirmwareVersion());
+    S.update_available = comparison === null ? data.state === "UPDATE AVAILABLE" : comparison > 0;
     refreshFirmwareUi();
     return S.update_available;
   }

--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -185,6 +185,7 @@ const scenarios = [
   { name: "settings", configured: true, width: 1280, height: 900 },
   { name: "settings-mobile", configured: true, width: 390, height: 900 },
   { name: "firmware-main-install", configured: true, width: 1280, height: 900 },
+  { name: "firmware-main-install-from-development-build", configured: true, width: 1280, height: 900, installedFirmwareVersion: "dev" },
   { name: "firmware-c6-install", configured: true, width: 1280, height: 900 },
   { name: "firmware-rollback", configured: true, width: 1280, height: 900 },
   { name: "firmware-rollback-failure", configured: true, width: 1280, height: 900, firmwareUploadFails: true },
@@ -1108,9 +1109,14 @@ function smokeAssertionsForScenario(scenario) {
             }
           }
 
-          if (${JSON.stringify(scenario.name)} === "firmware-main-install") {
+          if (${JSON.stringify(scenario.name)} === "firmware-main-install" || ${JSON.stringify(scenario.name)} === "firmware-main-install-from-development-build") {
             await requireFirmwarePanels();
             const install = disclosureByTitle("Firmware updates").querySelector(".fw-actions button");
+            if (${JSON.stringify(scenario.name)} === "firmware-main-install-from-development-build") {
+              if (install.textContent.trim() !== "Check for Update") throw new Error("Development build should require a device update check");
+              install.click();
+              await waitFor(() => install.textContent.trim() === "Install Update", 8000, "install action after development build update check");
+            }
             install.click();
             install.click();
             await waitFor(() => window.__smoke.posts.some((url) => url.indexOf("Firmware: Update/install") !== -1), 8000, "main firmware install");


### PR DESCRIPTION
## Summary

- trust the device’s confirmed update-available state when deciding whether to show the install action
- preserve semantic-version comparison as a fallback
- add regression coverage for development/custom firmware builds

## Root cause

The firmware card only treated an update as available when both installed and available versions matched the strict `v1.2.3` format. When a development or custom build reported a different version string, the device could confirm that an update was available but the web UI continued to show **Check for Update** instead of **Install Update**.

## User impact

After a successful firmware check, **Install Update** now appears whenever the display reports that an update is available, including from development or custom builds.

## Validation

- `npm run check:fast`
- `npm run test:web-compat`
- `npm run test:web-modules`
- `npm run test:web-smoke-cli`
- `npm run check:generated`
- Full browser smoke was attempted, but the local Chrome process aborted with `SIGABRT` before loading both changed and unchanged scenarios.

## Documentation decision

- [ ] Updated public docs or release-facing notes for user-visible behavior/configuration.
- [x] No docs needed because this does not change user-visible behavior/configuration.
- [ ] Docs follow-up needed before merge; explain below.

Docs notes:

- Existing firmware-update documentation already says **Install Update** appears after a successful check; this fix restores that documented behavior.